### PR TITLE
Fix bug where session completion not correctly communicated

### DIFF
--- a/libraries/tacacsrs_networking/examples/single_transaction.rs
+++ b/libraries/tacacsrs_networking/examples/single_transaction.rs
@@ -48,7 +48,7 @@ async fn main() {
 
     let accounting_request = AccountingRequest
     {
-        flags: TacacsAccountingFlags::START | TacacsAccountingFlags::STOP,
+        flags: TacacsAccountingFlags::START,
         authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
         priv_lvl: 0,
         authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
@@ -56,10 +56,42 @@ async fn main() {
         user: "admin".to_string(),
         port: "test".to_string(),
         rem_address: "1.1.1.1".to_string(),
-        args: vec!["cmd=test".to_string()],
+        args: vec![
+            "service=shell".to_string(),
+            "task_id=123".to_string(),
+            "cmd=test".to_string()
+        ],
     };
 
     let response = match session.send_accounting_request(accounting_request).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("Failed to send accounting request: {}", e);
+            return;
+        }
+    };
+
+    println!("Received accounting response: {:?}", response);
+
+    let session = Arc::new(connection.create_session().await.unwrap());
+
+    let response = match session.send_accounting_request(AccountingRequest
+        {
+            flags: TacacsAccountingFlags::STOP,
+            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
+            priv_lvl: 0,
+            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
+            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcNone,
+            user: "admin".to_string(),
+            port: "test".to_string(),
+            rem_address: "1.1.1.1".to_string(),
+            args: vec![
+                "service=shell".to_string(),
+                "task_id=123".to_string(),
+                "cmd=test".to_string()
+            ],
+        }
+    ).await {
         Ok(response) => response,
         Err(e) => {
             println!("Failed to send accounting request: {}", e);

--- a/libraries/tacacsrs_networking/src/connection.rs
+++ b/libraries/tacacsrs_networking/src/connection.rs
@@ -312,7 +312,7 @@ impl Connection
         }
     }
 
-    async fn create_channel(self: Arc<Self>) -> anyhow::Result<(DuplexChannel, u32)>
+    async fn create_channel(self: &Arc<Self>) -> anyhow::Result<(DuplexChannel, u32)>
     {
         // create some channel where the send side connects to the internal MPSC receiver
         // aka clone the sender and pass it to the DuplexChannel. Then create a new mpsc
@@ -346,7 +346,7 @@ impl Connection
         *can_accept_lock
     }
 
-    pub async fn create_session(self: Arc<Self>) -> anyhow::Result<Session>
+    pub async fn create_session(self: &Arc<Self>) -> anyhow::Result<Session>
     {
         if !self.can_create_sessions().await
         {

--- a/libraries/tacacsrs_networking/src/session.rs
+++ b/libraries/tacacsrs_networking/src/session.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tokio::sync::RwLock;
 
 use crate::duplex_channel::DuplexChannel;
@@ -8,7 +10,8 @@ pub struct Session
     pub session_id: u32,
     pub duplex_channel: DuplexChannel,
 
-    pub outgoing_sequence_number: RwLock<u8>
+    pub current_sequence_number: RwLock<u8>,
+    pub session_complete: RwLock<bool>
 }
 
 
@@ -20,12 +23,36 @@ impl Session
         {
             session_id,
             duplex_channel,
-            outgoing_sequence_number: 1_u8.into()
+            current_sequence_number: 1_u8.into(),
+            session_complete: false.into()
         }
     }
 
     pub fn session_id(&self) -> u32
     {
         self.session_id
+    }
+
+    pub async fn next_sequence_number(&self) -> u8
+    {
+        let mut sequence_number_lock = self.current_sequence_number.write().await;
+        let sequence_number = *sequence_number_lock;
+        *sequence_number_lock = sequence_number.wrapping_add(2);
+
+        sequence_number
+    }
+
+    pub async fn complete(self: &Arc<Self>)
+    {
+        let self_clone = self.clone();
+        let mut session_complete_lock = self_clone.session_complete.write().await;
+        *session_complete_lock = true;
+    }
+
+    pub async fn is_complete(self: &Arc<Self>) -> bool
+    {
+        let self_clone = self.clone();
+        let session_complete_lock = self_clone.session_complete.read().await;
+        *session_complete_lock
     }
 }


### PR DESCRIPTION
This pull request focuses on enhancing the session management and accounting request handling in the `tacacsrs_networking` library. The changes include updates to the `Session` struct, modifications to the `Connection` and `AccountingSessionTrait` implementations, and improvements to the example usage in `single_transaction.rs`.

### Session Management Enhancements:

* [`libraries/tacacsrs_networking/src/session.rs`](diffhunk://#diff-2b851549cf7d0a3390f3dc7a088af66fc8225f8d2dcfa8bab42156ddcf870c18R1-R2): Introduced `session_complete` and `current_sequence_number` fields in the `Session` struct. Added methods `next_sequence_number`, `complete`, and `is_complete` to manage session state and sequence numbers. [[1]](diffhunk://#diff-2b851549cf7d0a3390f3dc7a088af66fc8225f8d2dcfa8bab42156ddcf870c18R1-R2) [[2]](diffhunk://#diff-2b851549cf7d0a3390f3dc7a088af66fc8225f8d2dcfa8bab42156ddcf870c18L11-R14) [[3]](diffhunk://#diff-2b851549cf7d0a3390f3dc7a088af66fc8225f8d2dcfa8bab42156ddcf870c18L23-R57)

### Connection and Channel Updates:

* [`libraries/tacacsrs_networking/src/connection.rs`](diffhunk://#diff-51ee7ee0e586d908430ee7597060b1f28f027ec5e20a72894bced5e1285aa71fL315-R315): Changed the `create_channel` and `create_session` methods to take a reference to `Arc<Self>` instead of consuming the `Arc<Self>`. [[1]](diffhunk://#diff-51ee7ee0e586d908430ee7597060b1f28f027ec5e20a72894bced5e1285aa71fL315-R315) [[2]](diffhunk://#diff-51ee7ee0e586d908430ee7597060b1f28f027ec5e20a72894bced5e1285aa71fL349-R349)

### Accounting Request Handling:

* [`libraries/tacacsrs_networking/src/sessions/accounting_session.rs`](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69L13-R30): Updated `send_accounting_request` to check if the session is complete before proceeding and to mark the session as complete after receiving a reply. Adjusted the sequence number handling to use the new `next_sequence_number` method. [[1]](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69L13-R30) [[2]](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69R51-R57)

### Example Usage Improvements:

* [`libraries/tacacsrs_networking/examples/single_transaction.rs`](diffhunk://#diff-b719436a63f2d93f10f3202f6fac01a43fd57ddf46fc579f13e598ab08b1d504L51-R63): Modified the example to include additional arguments in the `AccountingRequest` and added a new accounting request to demonstrate session reuse. [[1]](diffhunk://#diff-b719436a63f2d93f10f3202f6fac01a43fd57ddf46fc579f13e598ab08b1d504L51-R63) [[2]](diffhunk://#diff-b719436a63f2d93f10f3202f6fac01a43fd57ddf46fc579f13e598ab08b1d504R75-R102)