### PR TITLE
Add TACACS with TLS 1.3 support

### DIFF
--- a/executables/tacon/src/commands/accounting.rs
+++ b/executables/tacon/src/commands/accounting.rs
@@ -1,16 +1,11 @@
-use std::sync::Arc;
-
 use tacacsrs_messages::accounting::reply::AccountingReply;
 use tacacsrs_messages::accounting::request::AccountingRequest;
-use tacacsrs_messages::enumerations::{
-    TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService,
-    TacacsAuthenticationType,
-};
+use tacacsrs_messages::enumerations::*;
 use tacacsrs_networking::session::Session;
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
 
 pub async fn send_accounting_request(
-    session: &Arc<Session>,
+    session: &Session,
     user: &str,
     port: &str,
     rem_address: &str,
@@ -39,8 +34,7 @@ pub async fn send_accounting_request(
         args,
     };
 
-    let session_clone = session.clone();
-    let response = match session_clone.send_accounting_request(accounting_request).await {
+    let response = match session.send_accounting_request(accounting_request).await {
         Ok(response) => response,
         Err(e) => {
             return Err(anyhow::Error::msg(format!(

--- a/executables/tacon/src/commands/accounting.rs
+++ b/executables/tacon/src/commands/accounting.rs
@@ -51,7 +51,7 @@ pub async fn send_accounting_request(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    
 
     #[test]
     fn test_send_accounting_request() {

--- a/executables/tacon/src/main.rs
+++ b/executables/tacon/src/main.rs
@@ -1,16 +1,12 @@
 mod commands;
 
-use std::{
-    net::{SocketAddr, ToSocketAddrs},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use anyhow::Context;
 use clap::{arg, Parser, Subcommand};
 use commands::accounting::send_accounting_request;
-use tacacsrs_networking::connection;
+use tacacsrs_networking::{tcp_connection::TcpConnectionTrait, traits::SessionCreationTrait};
 
-const DEFAULT_TACAS_PORT: u16 = 49;
 
 // Define the CLI struct
 #[derive(Parser)]
@@ -66,16 +62,6 @@ enum Commands {
     Authorization,
 }
 
-fn resolve_hostname(hostname: &str) -> anyhow::Result<Vec<SocketAddr>> {
-    let address = if hostname.contains(':') {
-        hostname.to_string()
-    } else {
-        format!("{}:{}", hostname, DEFAULT_TACAS_PORT) // Use the default TACACS+ port if none is specified
-    };
-
-    let addrs_iter = address.to_socket_addrs()?;
-    Ok(addrs_iter.collect())
-}
 
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     println!("Running with verbose level: {}", cli.verbose);
@@ -91,35 +77,21 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         println!("Running in batch mode, with file: {}", batch_file);
     }
 
-    let sock_addrs = resolve_hostname(&cli.server_addr)?;
+    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(&cli.server_addr).await?;
 
-    let session = 'connection_loop: {
-        for addr in sock_addrs {
+    let obfuscation_key = match cli.obfuscation_key {
+        Some(key) => Some(key.to_owned().into_bytes()),
+        None => Option::None,
+    };
 
-            let connection = Arc::new(
-                tacacsrs_networking::tcp_connection::TcpConnection::new(
-                    cli.obfuscation_key.to_owned().map(|key| key.into_bytes())
-                )
-            );
+    let connection = Arc::new(
+        tacacsrs_networking::tcp_connection::TcpConnection::new(
+            obfuscation_key.as_deref()
+        )
+    );
 
-            match connection.clone().connect().await {
-                Ok(_) => {
-                    println!(
-                        "Successfully connected to server at {}",
-                        connection_info.ip_socket
-                    );
-
-                    let session = Arc::new(connection.create_session().await.unwrap());
-                    break 'connection_loop Ok(session);
-                }
-                Err(e) => {
-                    println!("Failed to connect: {}", e); //TODO: Log this error
-                    // return Err(anyhow::Error::msg(format!("Failed to connect: {}", e)));
-                }
-            }
-        }
-        Err(anyhow::Error::msg("Failed to connect to any server"))
-    }?; // Unwrap the session if it was created successfully
+    connection.run(tcp_connection).await?;
+    let session = connection.create_session().await?;
 
     if let Some(command) = &cli.command {
         println!("Running command: {:?}", command);

--- a/executables/tacon/src/main.rs
+++ b/executables/tacon/src/main.rs
@@ -79,10 +79,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
 
     let tcp_connection = tacacsrs_networking::helpers::connect_tcp(&cli.server_addr).await?;
 
-    let obfuscation_key = match cli.obfuscation_key {
-        Some(key) => Some(key.to_owned().into_bytes()),
-        None => Option::None,
-    };
+    let obfuscation_key = cli.obfuscation_key.map(|key| key.to_owned().into_bytes());
 
     let connection = Arc::new(
         tacacsrs_networking::tcp_connection::TcpConnection::new(

--- a/executables/tacon/src/main.rs
+++ b/executables/tacon/src/main.rs
@@ -95,12 +95,12 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
 
     let session = 'connection_loop: {
         for addr in sock_addrs {
-            let connection_info = connection::ConnectionInfo {
-                ip_socket: addr,
-                obfuscation_key: cli.obfuscation_key.to_owned().map(|key| key.into_bytes()),
-            };
 
-            let connection = Arc::new(connection::Connection::new(&connection_info));
+            let connection = Arc::new(
+                tacacsrs_networking::tcp_connection::TcpConnection::new(
+                    cli.obfuscation_key.to_owned().map(|key| key.into_bytes())
+                )
+            );
 
             match connection.clone().connect().await {
                 Ok(_) => {

--- a/libraries/tacacsrs_messages/src/accounting/request.rs
+++ b/libraries/tacacsrs_messages/src/accounting/request.rs
@@ -337,7 +337,7 @@ mod tests
     fn test_read_string_exception_not_enough_data() {
         let data = vec![65_u8, 66, 67, 68, 69, 70];
         let mut cursor = Cursor::new(data.as_slice());
-        let _s = match AccountingRequest::read_string(&mut cursor, 700) {
+        match AccountingRequest::read_string(&mut cursor, 700) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Remaining buffer too short"), "Error actual: {}", err);
@@ -351,7 +351,7 @@ mod tests
     #[test]
     fn test_read_bytes_not_enough_data() {
         let data = vec![65_u8, 66, 67, 68, 69, 70];
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Data too short"), "Error actual: {}", err);
@@ -366,7 +366,7 @@ mod tests
     fn test_read_bytes_incorrect_accounting_flags() {
         let mut data = generate_accounting_request_data();
         data[0] = 0b11111111;
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid flags. Conversion failed with error"), "Error actual: {}", err);
@@ -381,7 +381,7 @@ mod tests
     fn test_read_bytes_incorrect_authen_method() {
         let mut data = generate_accounting_request_data();
         data[1] = 0b11111111;
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid authen_method. Conversion failed with error"), "Error actual: {}", err);
@@ -396,7 +396,7 @@ mod tests
     fn test_read_bytes_incorrect_authen_type() {
         let mut data = generate_accounting_request_data();
         data[3] = 0b11111111;
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid authen_type. Conversion failed with error"), "Error actual: {}", err);
@@ -411,7 +411,7 @@ mod tests
     fn test_read_bytes_incorrect_authen_service() {
         let mut data = generate_accounting_request_data();
         data[4] = 0b11111111;
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid authen_service. Conversion failed with error"), "Error actual: {}", err);
@@ -426,7 +426,7 @@ mod tests
     fn test_packet_has_nonzero_argcount_but_missing_arg_sizes_data() {
         let mut data = generate_accounting_request_data();
         data.truncate(TACACS_ACCOUNTING_REQUEST_MIN_LENGTH);
-        let _s = match AccountingRequest::from_bytes(data.as_slice()) {
+        match AccountingRequest::from_bytes(data.as_slice()) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid arg_size"), "Error actual: {}", err);
@@ -476,7 +476,7 @@ mod tests
 
         let packet = Packet::new(header, data).unwrap();
 
-        let _accounting_request = match AccountingRequest::from_packet(&packet) {
+        match AccountingRequest::from_packet(&packet) {
             Ok(_) => assert!(false),
             Err(err) => {
                 assert!(err.to_string().contains("Invalid body length"), "Error actual: {}", err);

--- a/libraries/tacacsrs_messages/src/header.rs
+++ b/libraries/tacacsrs_messages/src/header.rs
@@ -111,9 +111,9 @@ mod tests {
         let tacacs_type = tacacs_type_o.unwrap_or(TacacsType::TacPlusAccounting);
         let tacacs_flags = tacacs_flags_o.unwrap_or(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
 
-        let sequence_number = sequence_number_o.unwrap_or(1 as u8);
-        let session_id = session_id_o.unwrap_or(0xdeadbeef as u32);
-        let length = length_o.unwrap_or(1 as u32);
+        let sequence_number = sequence_number_o.unwrap_or(1_u8);
+        let session_id = session_id_o.unwrap_or(0xdeadbeef_u32);
+        let length = length_o.unwrap_or(1_u32);
 
         let session_id_bytes = session_id.to_be_bytes();
         let length_bytes = length.to_be_bytes();
@@ -126,11 +126,11 @@ mod tests {
             session_id_bytes[0], session_id_bytes[1], session_id_bytes[2], session_id_bytes[3],
             length_bytes[0], length_bytes[1], length_bytes[2], length_bytes[3]
         ];
-        return binary_data;
+        binary_data
     }
 
     fn generate_default_packet() -> [u8; 12] {
-        return generate_packet(Option::None, Option::None, Option::None, Option::None, Option::None, Option::None, Option::None);
+        generate_packet(Option::None, Option::None, Option::None, Option::None, Option::None, Option::None, Option::None)
     }
 
     #[test]
@@ -145,12 +145,12 @@ mod tests {
             },
         };
 
-        assert_eq!(header.major_version as u8, 0xc as u8, "Major version mismatch");
-        assert_eq!(header.minor_version as u8, 1 as u8, "Minor version mismatch");
-        assert_eq!(header.tacacs_type as u8, 3 as u8, "TACACS+ type mismatch");
+        assert_eq!(header.major_version as u8, 0xc_u8, "Major version mismatch");
+        assert_eq!(header.minor_version as u8, 1_u8, "Minor version mismatch");
+        assert_eq!(header.tacacs_type as u8, 3_u8, "TACACS+ type mismatch");
         assert_eq!(header.seq_no, 1, "Sequence number mismatch");
         assert_eq!(header.flags.bits(), (0xff & 0x01) as u8, "Flags mismatch");
-        assert_eq!(header.session_id as u32, 0xdeadbeef as u32, "Session ID mismatch");
+        assert_eq!(header.session_id as u32, 0xdeadbeef_u32, "Session ID mismatch");
         assert_eq!(header.length, 1, "Length mismatch");
     }
 
@@ -159,7 +159,7 @@ mod tests {
         let binary_data_expected_length = generate_default_packet();
         let binary_data_short = &binary_data_expected_length[0..TACACS_HEADER_LENGTH-1];
     
-        let _header = match Header::from_bytes(&binary_data_short) {
+        let _header = match Header::from_bytes(binary_data_short) {
             Ok(data) => data,
             Err(e) => {
                 assert!(e.to_string().contains("Data too short"), "Error: {}", e);

--- a/libraries/tacacsrs_messages/src/obfuscation.rs
+++ b/libraries/tacacsrs_messages/src/obfuscation.rs
@@ -122,15 +122,15 @@ mod tests
         ];
 
         let packet = Packet::from_bytes(&encrypted_bytes).unwrap();
-        assert_eq!(packet.header().flags.contains(crate::enumerations::TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG), false);
+        assert!(!packet.header().flags.contains(crate::enumerations::TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG));
         assert_eq!(packet.header().length, 34);
 
         let obfuscation_key = b"XX";
-        let body_data = convert(packet.header(), &packet.body(), obfuscation_key);
+        let body_data = convert(packet.header(), packet.body(), obfuscation_key);
         assert_eq!(body_data, decrypted_bytes);
 
         let decrypted_packet = packet.as_deobfuscated(obfuscation_key).unwrap();
         assert_eq!(decrypted_packet.body(), &decrypted_bytes);
-        assert_eq!(decrypted_packet.header().flags.contains(crate::enumerations::TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG), true);
+        assert!(decrypted_packet.header().flags.contains(crate::enumerations::TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG));
     }
 }

--- a/libraries/tacacsrs_networking/Cargo.toml
+++ b/libraries/tacacsrs_networking/Cargo.toml
@@ -10,9 +10,13 @@ tacacsrs-messages = { path = "../tacacsrs_messages" }
 async-trait = "0.1.82"
 rand = "0.8.5"
 log = "0.4.22"
+tokio-rustls = { version = "0.26.0", default-features = false, features = ["aws_lc_rs", "logging"] }
 
 [dev-dependencies]
+argh = "0.1.12"
 console-subscriber = "0.4.0"
+rustls-pemfile = "2.1.3"
+webpki-roots = "0.26.6"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/libraries/tacacsrs_networking/examples/multiple_transactions.rs
+++ b/libraries/tacacsrs_networking/examples/multiple_transactions.rs
@@ -4,65 +4,65 @@ use std::vec;
 
 use tacacsrs_messages::accounting::request::AccountingRequest;
 use tacacsrs_messages::enumerations::{TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType};
-use tacacsrs_networking::connection;
+use tacacsrs_networking::{connection, session};
 
+use tacacsrs_networking::session::Session;
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
+use tacacsrs_networking::traits::SessionCreationTrait;
 
 
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let _ = init_logging();
+    let hostname = "tacacsserver.local";
+    let obfuscation_key = Some(b"tac_plus_key".to_vec());
 
     #[cfg(tokio_unstable)]
     {
         console_subscriber::init();
     }
 
-    let mut server_address_list = lookup_host("tacacsserver.local:49").await.unwrap();
-    let server_addr = match server_address_list.next() {
-        Some(SocketAddr::V4(addr)) => addr.ip().clone(),
-        _ => panic!("No valid IPv4 address found for tacacsserver.local"),
-    };
+    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname.to_string()).await?;
+    let tacacs_connection = Arc::new(tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key));
+    tacacs_connection.run(tcp_connection).await?;
 
-    println!("Resolved tacacsserver.local to {}", server_addr);
-    
-    let connection_info = connection::ConnectionInfo {
-        ip_socket: SocketAddr::new(IpAddr::V4(server_addr), 49),
-        obfuscation_key: Some(b"tac_plus_key".to_vec()),
-    };
+    let session_count = 100000;
 
-    let connection = Arc::new(connection::Connection::new(&connection_info));
+    let session_creation = (0..session_count).map(|_| {
+        let connection = tacacs_connection.clone();
+        tokio::spawn(async move {
+            connection.create_session().await
+        })
+    });
 
-    match connection.clone().connect().await {
-        Ok(_) => {
-            println!("Successfully connected to server at {}", connection_info.ip_socket);
-        }
-        Err(e) => {
-            println!("Failed to connect: {}", e);
-        }
+    let mut sessions = Vec::<Session>::with_capacity(session_count);
+    for session in session_creation {
+        let session = match session.await? {
+            Ok(session) => session,
+            Err(e) => {
+                println!("Failed to create session: {}", e);
+                return Err(e);
+            }
+        };
+
+        sessions.push(session);
     }
 
-    let mut handles = vec![];
-
-    for _ in 0..100000 {
-        let connection_clone = Arc::clone(&connection);
-        let handle = tokio::spawn(async move {
-            send_test_request(connection_clone).await;
-        });
-
-        handles.push(handle);
-    }
+    let handles : Vec::<JoinHandle<anyhow::Result<()>>> = sessions.into_iter().map(|session| {
+        tokio::spawn(async move {
+            send_test_request(session).await
+        })
+    }).collect();
 
     for handle in handles {
-        handle.await.unwrap();
+        let _ = handle.await?;
     }
 
+    Ok(())
 }
 
-async fn send_test_request(connection : Arc<connection::Connection>) {
-    let session = Arc::new(connection.create_session().await.unwrap());
-
+async fn send_test_request(session : Session) -> anyhow::Result<()> {
     let accounting_request = AccountingRequest
     {
         flags: TacacsAccountingFlags::START | TacacsAccountingFlags::STOP,
@@ -80,17 +80,19 @@ async fn send_test_request(connection : Arc<connection::Connection>) {
         Ok(response) => response,
         Err(e) => {
             println!("Failed to send accounting request: {}", e);
-            return;
+            return Err(e);
         }
     };
 
-    //println!("Received accounting response: {:?}", response);
+    Ok(())
 }
 
 
 use log::{Record, Level, Metadata};
 use log::{SetLoggerError, LevelFilter};
+use tacacsrs_networking::tcp_connection::TcpConnectionTrait;
 use tokio::net::lookup_host;
+use tokio::task::JoinHandle;
 static LOGGER: SimpleLogger = SimpleLogger;
 
 struct SimpleLogger;

--- a/libraries/tacacsrs_networking/examples/multiple_transactions.rs
+++ b/libraries/tacacsrs_networking/examples/multiple_transactions.rs
@@ -4,9 +4,13 @@ use std::vec;
 use tacacsrs_messages::accounting::request::AccountingRequest;
 use tacacsrs_messages::enumerations::{TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType};
 
+use tacacsrs_networking::helpers::*;
 use tacacsrs_networking::session::Session;
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
 use tacacsrs_networking::traits::SessionCreationTrait;
+use tacacsrs_networking::tcp_connection::TcpConnectionTrait;
+use tokio::task::JoinHandle;
+
 
 
 
@@ -21,12 +25,20 @@ async fn main() -> anyhow::Result<()> {
         console_subscriber::init();
     }
 
-    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname).await?;
+    let tcp_connection = connect_tcp(hostname).await?;
     let tacacs_connection = Arc::new(
         tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key.as_deref())
     );
     
     tacacs_connection.run(tcp_connection).await?;
+
+    // use ssl:
+    // let tcp_stream = connect_tcp(hostname).await?;
+    // let tls_stream = connect_tls(tcp_stream, "tacacsserver.local").await?;
+    // let tacacs_connection = Arc::new(
+    //     tacacsrs_networking::tls_connection::TlsConnection::new(obfuscation_key.as_deref())
+    // );
+    // tacacs_connection.run(tls_stream).await?;
 
     let session_count = 100000;
 
@@ -91,8 +103,7 @@ async fn send_test_request(session : Session) -> anyhow::Result<()> {
 
 use log::{Record, Level, Metadata};
 use log::{SetLoggerError, LevelFilter};
-use tacacsrs_networking::tcp_connection::TcpConnectionTrait;
-use tokio::task::JoinHandle;
+
 static LOGGER: SimpleLogger = SimpleLogger;
 
 struct SimpleLogger;

--- a/libraries/tacacsrs_networking/examples/multiple_transactions.rs
+++ b/libraries/tacacsrs_networking/examples/multiple_transactions.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
-use std::net::{IpAddr, SocketAddr};
 use std::vec;
 
 use tacacsrs_messages::accounting::request::AccountingRequest;
 use tacacsrs_messages::enumerations::{TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType};
-use tacacsrs_networking::{connection, session};
 
 use tacacsrs_networking::session::Session;
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
@@ -23,8 +21,11 @@ async fn main() -> anyhow::Result<()> {
         console_subscriber::init();
     }
 
-    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname.to_string()).await?;
-    let tacacs_connection = Arc::new(tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key));
+    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname).await?;
+    let tacacs_connection = Arc::new(
+        tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key.as_deref())
+    );
+    
     tacacs_connection.run(tcp_connection).await?;
 
     let session_count = 100000;
@@ -91,7 +92,6 @@ async fn send_test_request(session : Session) -> anyhow::Result<()> {
 use log::{Record, Level, Metadata};
 use log::{SetLoggerError, LevelFilter};
 use tacacsrs_networking::tcp_connection::TcpConnectionTrait;
-use tokio::net::lookup_host;
 use tokio::task::JoinHandle;
 static LOGGER: SimpleLogger = SimpleLogger;
 

--- a/libraries/tacacsrs_networking/examples/single_transaction.rs
+++ b/libraries/tacacsrs_networking/examples/single_transaction.rs
@@ -1,50 +1,30 @@
 
 use std::sync::Arc;
-use std::net::{IpAddr, SocketAddr};
 use std::vec;
 
 use tacacsrs_messages::accounting::request::AccountingRequest;
-use tacacsrs_messages::enumerations::{TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType};
-use tacacsrs_networking::connection;
+use tacacsrs_messages::enumerations::*;
 
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
 
 
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let _ = init_logging();
+    let hostname = "tacacsserver.local";
+    let obfuscation_key = Some(b"tac_plus_key".to_vec());
 
     #[cfg(tokio_unstable)]
     {
         console_subscriber::init();
     }
 
-    let mut server_address_list = lookup_host("tacacsserver.local:49").await.unwrap();
-    let server_addr = match server_address_list.next() {
-        Some(SocketAddr::V4(addr)) => addr.ip().clone(),
-        _ => panic!("No valid IPv4 address found for tacacsserver.local"),
-    };
+    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname.to_string()).await?;
+    let tacacs_connection = Arc::new(tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key));
+    tacacs_connection.run(tcp_connection).await?;
 
-    println!("Resolved tacacsserver.local to {}", server_addr);
-    
-    let connection_info = connection::ConnectionInfo {
-        ip_socket: SocketAddr::new(IpAddr::V4(server_addr), 49),
-        obfuscation_key: Some(b"tac_plus_key".to_vec()),
-    };
-
-    let connection = Arc::new(connection::Connection::new(&connection_info));
-
-    match connection.clone().connect().await {
-        Ok(_) => {
-            println!("Successfully connected to server at {}", connection_info.ip_socket);
-        }
-        Err(e) => {
-            println!("Failed to connect: {}", e);
-        }
-    }
-
-    let session = Arc::new(connection.create_session().await.unwrap());
+    let session = tacacs_connection.clone().create_session().await?;
 
     let accounting_request = AccountingRequest
     {
@@ -67,13 +47,15 @@ async fn main() {
         Ok(response) => response,
         Err(e) => {
             println!("Failed to send accounting request: {}", e);
-            return;
+            return Err(e);
         }
     };
 
-    println!("Received accounting response: {:?}", response);
+    println!("Received accounting response: {:#?}", response);
 
-    let session = Arc::new(connection.create_session().await.unwrap());
+
+
+    let session = tacacs_connection.clone().create_session().await?;
 
     let response = match session.send_accounting_request(AccountingRequest
         {
@@ -95,18 +77,21 @@ async fn main() {
         Ok(response) => response,
         Err(e) => {
             println!("Failed to send accounting request: {}", e);
-            return;
+            return Err(e);
         }
     };
 
-    println!("Received accounting response: {:?}", response);
+    println!("Received accounting response: {:#?}", response);
+
+    Ok(())
 }
 
 
 
 use log::{Record, Level, Metadata};
 use log::{SetLoggerError, LevelFilter};
-use tokio::net::lookup_host;
+use tacacsrs_networking::tcp_connection::TcpConnectionTrait;
+use tacacsrs_networking::traits::SessionCreationTrait;
 static LOGGER: SimpleLogger = SimpleLogger;
 
 struct SimpleLogger;

--- a/libraries/tacacsrs_networking/examples/single_transaction.rs
+++ b/libraries/tacacsrs_networking/examples/single_transaction.rs
@@ -20,8 +20,10 @@ async fn main() -> anyhow::Result<()> {
         console_subscriber::init();
     }
 
-    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname.to_string()).await?;
-    let tacacs_connection = Arc::new(tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key));
+    let tcp_connection = tacacsrs_networking::helpers::connect_tcp(hostname).await?;
+    let tacacs_connection = Arc::new(
+        tacacsrs_networking::tcp_connection::TcpConnection::new(obfuscation_key.as_deref())
+    );
     tacacs_connection.run(tcp_connection).await?;
 
     let session = tacacs_connection.clone().create_session().await?;

--- a/libraries/tacacsrs_networking/examples/tls_client.rs
+++ b/libraries/tacacsrs_networking/examples/tls_client.rs
@@ -1,0 +1,163 @@
+use std::io;
+use std::net::ToSocketAddrs;
+use std::sync::Arc;
+
+use argh::FromArgs;
+use tacacsrs_messages::accounting::request::AccountingRequest;
+use tacacsrs_messages::enumerations::*;
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::pki_types;
+use tokio_rustls::{rustls, TlsConnector};
+
+use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
+
+
+use rustls::crypto::aws_lc_rs as provider;
+
+/// Tokio Rustls client example
+#[derive(FromArgs)]
+struct Options {
+    /// host
+    #[argh(positional)]
+    host: String,
+
+    /// port
+    #[argh(option, short = 'p', default = "443")]
+    port: u16,
+
+    /// domain
+    #[argh(option, short = 'd')]
+    domain: Option<String>
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let options: Options = argh::from_env();
+
+    let addr = (options.host.as_str(), options.port)
+        .to_socket_addrs()?
+        .next()
+        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+    let domain = options.domain.unwrap_or(options.host);
+
+    let root_cert_store = rustls::RootCertStore::empty();
+    let supported_tls_versions = vec![&rustls::version::TLS13];
+    let mut config = rustls::ClientConfig::builder_with_protocol_versions(supported_tls_versions.as_slice())
+        .with_root_certificates(root_cert_store)
+        .with_no_client_auth();
+
+    println!("resumption: {:?}", config.resumption);
+    config.resumption = config.resumption.tls12_resumption(rustls::client::Tls12Resumption::Disabled);
+    config.enable_sni = false;
+
+    config.dangerous().set_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
+        provider::default_provider(),
+    )));
+
+    println!("Config: {:#?}", config);
+
+
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let stream = TcpStream::connect(&addr).await.unwrap();
+
+    let domain = pki_types::ServerName::try_from(domain.as_str())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))
+        .unwrap()
+        .to_owned();
+
+    let stream = connector.connect(domain, stream).await?;
+
+    let connection = Arc::new(tacacsrs_networking::tls_connection::TlsConnection::new());
+    connection.clone().connect(stream).await?;
+
+    let session = connection.create_session().await?;
+
+    let response = match session.send_accounting_request(AccountingRequest
+        {
+            flags: TacacsAccountingFlags::STOP,
+            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
+            priv_lvl: 0,
+            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
+            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcNone,
+            user: "admin".to_string(),
+            port: "test".to_string(),
+            rem_address: "1.1.1.1".to_string(),
+            args: vec![
+                "service=shell".to_string(),
+                "task_id=123".to_string(),
+                "cmd=test".to_string()
+            ],
+        }
+    ).await {
+        Ok(response) => response,
+        Err(e) => {
+            println!("Failed to send accounting request: {}", e);
+            return Err(e);
+        }
+    };
+
+    println!("Received accounting response: {:?}", response);
+
+    Ok(())
+}
+
+mod danger {
+    use tokio_rustls::rustls;
+    use tokio_rustls::rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use rustls::client::danger::HandshakeSignatureValid;
+    use rustls::crypto::{verify_tls13_signature, CryptoProvider};
+    use rustls::DigitallySignedStruct;
+
+    #[derive(Debug)]
+    pub struct NoCertificateVerification(CryptoProvider);
+
+    impl NoCertificateVerification {
+        pub fn new(provider: CryptoProvider) -> Self {
+            Self(provider)
+        }
+    }
+
+    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp: &[u8],
+            _now: UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            println!("verify_server_cert");
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Err(rustls::Error::General("TLS 1.2 not supported".to_string()))
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.0.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            self.0
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+}

--- a/libraries/tacacsrs_networking/examples/tls_client.rs
+++ b/libraries/tacacsrs_networking/examples/tls_client.rs
@@ -1,20 +1,14 @@
-use std::io;
-use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
 use tacacsrs_messages::accounting::request::AccountingRequest;
 use tacacsrs_messages::enumerations::*;
 use tacacsrs_networking::helpers::connect_tcp;
-use tokio::net::TcpStream;
-use tokio_rustls::rustls::pki_types;
-use tokio_rustls::{rustls, TlsConnector};
 
 use tacacsrs_networking::sessions::accounting_session::AccountingSessionTrait;
 use tacacsrs_networking::traits::SessionCreationTrait;
-use tacacsrs_networking::tls_connection::{TlsConnection, TLSConnectionTrait};
+use tacacsrs_networking::tls_connection::TLSConnectionTrait;
 
 
-use rustls::crypto::aws_lc_rs as provider;
 
 use tacacsrs_networking::helpers::*;
 
@@ -28,7 +22,9 @@ async fn main() -> anyhow::Result<()> {
     let tcp_stream = connect_tcp(hostname).await?;
     let tls_stream = connect_tls(tcp_stream, hostname).await?;
 
-    let connection = Arc::new(tacacsrs_networking::tls_connection::TlsConnection::new());
+    let connection = Arc::new(
+        tacacsrs_networking::tls_connection::TlsConnection::new(obfuscation_key.as_deref())
+    );
     connection.run(tls_stream).await?;
 
     let session = connection.create_session().await?;
@@ -60,64 +56,4 @@ async fn main() -> anyhow::Result<()> {
     println!("Received accounting response: {:#?}", response);
 
     Ok(())
-}
-
-mod danger {
-    use tokio_rustls::rustls;
-    use tokio_rustls::rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-    use rustls::client::danger::HandshakeSignatureValid;
-    use rustls::crypto::{verify_tls13_signature, CryptoProvider};
-    use rustls::DigitallySignedStruct;
-
-    #[derive(Debug)]
-    pub struct NoCertificateVerification(CryptoProvider);
-
-    impl NoCertificateVerification {
-        pub fn new(provider: CryptoProvider) -> Self {
-            Self(provider)
-        }
-    }
-
-    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName<'_>,
-            _ocsp: &[u8],
-            _now: UnixTime,
-        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-            println!("verify_server_cert");
-            Ok(rustls::client::danger::ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Err(rustls::Error::General("TLS 1.2 not supported".to_string()))
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            verify_tls13_signature(
-                message,
-                cert,
-                dss,
-                &self.0.signature_verification_algorithms,
-            )
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-            self.0
-                .signature_verification_algorithms
-                .supported_schemes()
-        }
-    }
 }

--- a/libraries/tacacsrs_networking/src/connection.rs
+++ b/libraries/tacacsrs_networking/src/connection.rs
@@ -1,52 +1,31 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::sync::Arc;
-use tacacsrs_messages::enumerations::TacacsFlags;
-use tacacsrs_messages::packet::PacketTrait;
-use tacacsrs_messages::{header::Header, packet::Packet};
+use tacacsrs_messages::packet::Packet;
 
-use tacacsrs_messages::constants::TACACS_HEADER_LENGTH;
-use tokio::io::{AsyncWriteExt, AsyncReadExt};
 use tokio::sync::{mpsc, Mutex, RwLock};
-use tokio::net::TcpStream;
-use tokio::task::{self, JoinHandle};
+use tokio::task::JoinHandle;
 
 use crate::{duplex_channel::DuplexChannel, session::Session};
 
 
-#[derive(Clone)]
-pub struct ConnectionInfo
-{
-    pub ip_socket : SocketAddr,
-    pub obfuscation_key : Option<Vec<u8>>
-}
-
-
 pub struct Connection {
-    pub duplex_channels: RwLock<HashMap<u32, mpsc::Sender<Packet>>>,
-    connection_info: ConnectionInfo,
-
-    sender: tokio::sync::mpsc::Sender<Packet>,
-    receiver: Mutex<Option<tokio::sync::mpsc::Receiver<Packet>>>,
-
-    run_task : RwLock<Option<JoinHandle<anyhow::Result<()>>>>,
-
+    pub(crate) duplex_channels: RwLock<HashMap<u32, mpsc::Sender<Packet>>>,
+    pub(crate) sender: tokio::sync::mpsc::Sender<Packet>,
+    pub(crate) receiver: Mutex<Option<tokio::sync::mpsc::Receiver<Packet>>>,
+    pub(crate) run_task : RwLock<Option<JoinHandle<anyhow::Result<()>>>>,
+    
     can_accept_new_sessions: RwLock<bool>
 }
 
-
 impl Connection
 {
-    // Setup the information required for the TCP connection,
-    // but do not connect.
-    pub fn new(connection_info : &ConnectionInfo) -> Self
+    pub(crate) fn new() -> Self
     {
         let (sender, receiver) = mpsc::channel::<Packet>(32);
 
         Self
         {
             duplex_channels: HashMap::new().into(),
-            connection_info: connection_info.clone(),
             sender,
             receiver: Some(receiver).into(),
             run_task : None.into(),
@@ -54,265 +33,13 @@ impl Connection
         }
     }
 
-    pub async fn is_running(&self) -> bool
+    pub(crate) async fn disable_new_sessions(&self)
     {
-        let run_task_lock = self.run_task.read().await;
-        run_task_lock.as_ref().map(|f| f.is_finished()).unwrap_or(false)
+        let mut can_accept_lock = self.can_accept_new_sessions.write().await;
+        *can_accept_lock = false;
     }
 
-    pub async fn connect(self: Arc<Self>) -> anyhow::Result<()>
-    {
-        let stream = TcpStream::connect(self.connection_info.ip_socket).await?;
-
-        let self_clone = Arc::clone(&self);
-        task::spawn(async move {
-            self_clone.handle_connection(stream).await
-        });
-
-        Ok(())
-    }
-
-    async fn handle_connection(self: Arc<Self>, stream: TcpStream) -> anyhow::Result<()> {
-        let (reader, writer) = stream.into_split();
-
-        let write_task = {
-            let self_clone = Arc::clone(&self);
-            let receiver = self_clone.receiver.lock().await.take().unwrap();
-
-            task::spawn(async move {
-                match Connection::write_handler(receiver, writer, self_clone.connection_info.obfuscation_key.clone()).await
-                {
-                    Ok(_) => Ok(()),
-                    Err(e) => {
-                        log::error!(
-                            target: "tacacsrs_networking::connection::handle_connection",
-                            "Write task failed with error: {}",
-                            e.to_string()
-                        );
-
-                        Err(e)
-                    }
-                }
-            })
-        };
-
-        let read_task = {
-            let self_clone = Arc::clone(&self);
-            task::spawn(async move {
-                match self_clone.read_handler(reader).await {
-                    Ok(_) => Ok(()),
-                    Err(e) => {
-                        log::error!(
-                            target: "tacacsrs_networking::connection::handle_connection",
-                            "Read task failed with error: {}",
-                            e.to_string()
-                        );
-
-                        Err(e)
-                    }
-                }
-            })
-        };
-
-        // Wait for both tasks to complete, and return an error if either task fails.
-        let (write_result, read_result) = tokio::try_join!(write_task, read_task)?;
-
-        // Set the can_accept_new_sessions flag to false, as the connection is now closed.
-        {
-            let mut can_accept_lock = self.can_accept_new_sessions.write().await;
-            *can_accept_lock = false;
-        }
-
-        // Bubble up any errors that occurred during the tasks.
-        write_result?;
-        read_result?;
-
-        // Return Ok if both tasks completed successfully.
-        Ok(())
-    }
-
-    async fn write_handler(mut receiver : tokio::sync::mpsc::Receiver<Packet>, mut writer: tokio::net::tcp::OwnedWriteHalf, obfuscation_key : Option<Vec<u8>>) -> anyhow::Result<()> {
-        loop {
-            let mut packet = match receiver.recv().await {
-                Some(packet) => packet,
-                None => {
-                    log::error!(
-                        target: "tacacsrs_networking::connection::write_handler",
-                        "No packet received from channel"
-                    );
-
-                    return Err(anyhow::Error::msg("No packet received"))
-                }
-            };
-
-            let session_id = packet.header().session_id;
-
-            log::info!(
-                target: "tacacsrs_networking::connection::write_handler",
-                "Received packet for session id {} to send to network",
-                session_id
-            );
-
-            let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
-            let mut did_obfuscate = false;
-            packet = match &obfuscation_key {
-                Some(key) => match is_packet_deobfuscated {
-                    true => {
-                        did_obfuscate = true;
-                        packet.to_obfuscated(key)
-                    },
-                    false => packet
-                },
-                None => packet
-            };
-
-            if did_obfuscate {
-                log::info!(
-                    target: "tacacsrs_networking::connection::write_handler",
-                    "Obfuscated packet for session id {}",
-                    session_id
-                );
-            }
-
-            let bytes = packet.to_bytes();
-            
-            writer.write_all(&bytes).await?;
-
-            log::info!(
-                target: "tacacsrs_networking::connection::write_handler",
-                "Sent packet for session id {} to network",
-                session_id
-            );
-        }
-    }
-
-    async fn read_handler(self: Arc<Self>, mut _reader: tokio::net::tcp::OwnedReadHalf) -> anyhow::Result<()> {
-        loop {
-            let mut header_buffer = [0_u8; TACACS_HEADER_LENGTH];
-
-            match _reader.read_exact(&mut header_buffer).await {
-                Ok(_) => (),
-                Err(e) => {
-                    log::error!(
-                        target: "tacacsrs_networking::connection::read_handler",
-                        "Failed to read header from network due to error: {}",
-                        e.to_string()
-                    );
-                    return Err(anyhow::Error::msg(e.to_string()))
-                }
-            };
-
-            let header = match Header::from_bytes(&header_buffer) {
-                Ok(header) => header,
-                Err(e) => {
-                    log::error!(
-                        target: "tacacsrs_networking::connection::read_handler",
-                        "Failed to parse header due to error: {}",
-                        e.to_string()
-                    );
-
-                    continue
-                }
-            };
-
-            let session_id = header.session_id;
-
-            log::info!(
-                target: "tacacsrs_networking::connection::read_handler",
-                "Received header with session id: {}. Loading body of length {}",
-                session_id, header.length
-            );
-
-            // Always read the body, regardless of the presence of the session. This is to prevent the 
-            // stream from getting out of sync.
-            let mut body_buffer = vec![0_u8; header.length as usize];
-            match _reader.read_exact(&mut body_buffer).await {
-                Ok(_) => (),
-                Err(e) => {
-                    log::error!(
-                        target: "tacacsrs_networking::connection::read_handler",
-                        "Failed to {} bytes from network for body session id {} due to error: {}",
-                        header.length, session_id, e.to_string()
-                    );
-
-                    return Err(anyhow::Error::msg(e.to_string()))
-                }
-            };
-
-            log::info!(
-                target: "tacacsrs_networking::connection::read_handler",
-                "Received body for session id: {}",
-                session_id
-            );
-
-            // Create a new packet and potentially deobfuscate it.
-            let mut packet =  match Packet::new(header, body_buffer) {
-                Ok(packet) => packet,
-                Err(e) => {
-                    log::error!(
-                        target: "tacacsrs_networking::connection::read_handler",
-                        "Could not load packet for session id {}. Failed with error: {}",
-                        session_id, e.to_string()
-                    );
-
-                    continue
-                }
-            };
-
-            let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
-            let mut did_deobfuscate = false;
-            packet = match &self.connection_info.obfuscation_key {
-                Some(key) => match is_packet_deobfuscated {
-                    true => packet,
-                    false => {
-                        did_deobfuscate = true;
-                        packet.to_deobfuscated(key)
-                    },
-                },
-                None => packet
-            };
-
-            if did_deobfuscate {
-                log::info!(
-                    target: "tacacsrs_networking::connection::read_handler",
-                    "Deobfuscated packet for session id: {}",
-                    session_id
-                );
-            }
-
-            // Get a read lock on the duplex_channels dictionary and 
-            // find the appropriate channel to forward the packet to.
-            let duplex_channels = self.duplex_channels.read().await;
-
-            match duplex_channels.get(&packet.header().session_id) {
-                Some(channel) => {
-                    log::info!(
-                        target: "tacacsrs_networking::connection::read_handler",
-                        "Found client channel for session id {}, forwarding packet",
-                        session_id
-                    );
-
-
-                    match channel.send(packet).await
-                    {
-                        Ok(_) => (),
-                        Err(e) => {
-                            log::warn!(
-                                target: "tacacsrs_networking::connection::read_handler",
-                                "Failed to send packet to client channel for session id: {} due to error: {}",
-                                session_id, e.to_string()
-                            );
-
-                            continue;
-                        }
-                    }
-                },
-                None => continue
-            };
-        }
-    }
-
-    async fn create_channel(self: &Arc<Self>) -> anyhow::Result<(DuplexChannel, u32)>
+    pub(crate) async fn create_channel(&self) -> anyhow::Result<(DuplexChannel, u32)>
     {
         // create some channel where the send side connects to the internal MPSC receiver
         // aka clone the sender and pass it to the DuplexChannel. Then create a new mpsc
@@ -339,14 +66,14 @@ impl Connection
         Ok((duplex_channel, session_id))
     }
 
-    pub async fn can_create_sessions(self: &Arc<Self>) -> bool
+
+    pub async fn can_create_sessions(&self) -> bool
     {
-        let self_clone = Arc::clone(self);
-        let can_accept_lock = self_clone.can_accept_new_sessions.read().await;
+        let can_accept_lock = self.can_accept_new_sessions.read().await;
         *can_accept_lock
     }
 
-    pub async fn create_session(self: &Arc<Self>) -> anyhow::Result<Session>
+    pub async fn create_session(&self) -> anyhow::Result<Session>
     {
         if !self.can_create_sessions().await
         {
@@ -363,4 +90,12 @@ impl Connection
 
         Ok(Session::new(session_id, duplex_channel))
     }
+
+    pub async fn is_running(&self) -> bool
+    {
+        let run_task_lock = self.run_task.read().await;
+        run_task_lock.as_ref().map(|f| f.is_finished()).unwrap_or(false)
+    }
 }
+
+

--- a/libraries/tacacsrs_networking/src/connection.rs
+++ b/libraries/tacacsrs_networking/src/connection.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 use tacacsrs_messages::packet::Packet;
 
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tokio::task::JoinHandle;
 
-use crate::{duplex_channel::DuplexChannel, session::Session};
+use crate::duplex_channel::DuplexChannel;
+use crate::session::Session;
 
 
 pub struct Connection {

--- a/libraries/tacacsrs_networking/src/connection.rs
+++ b/libraries/tacacsrs_networking/src/connection.rs
@@ -7,7 +7,6 @@ use tokio::task::JoinHandle;
 use crate::duplex_channel::DuplexChannel;
 use crate::session::Session;
 
-
 pub struct Connection {
     pub(crate) duplex_channels: RwLock<HashMap<u32, mpsc::Sender<Packet>>>,
     pub(crate) sender: tokio::sync::mpsc::Sender<Packet>,

--- a/libraries/tacacsrs_networking/src/helpers.rs
+++ b/libraries/tacacsrs_networking/src/helpers.rs
@@ -21,9 +21,16 @@ pub async fn connect_tcp(hostname : &str) -> anyhow::Result<tokio::net::TcpStrea
     {
         match tokio::net::TcpStream::connect(server_address).await
         {
-            Ok(stream) => return Ok(stream),
+            Ok(stream) => {
+                log::info!(
+                    target: "tacacsrs_networking::helpers::connect_tcp",
+                    "Connected to server: {}", server_address);
+                return Ok(stream)
+            },
             Err(e) => {
-                log::error!("Failed to connect to server: {}", e);
+                log::error!(
+                    target: "tacacsrs_networking::helpers::connect_tcp",
+                    "Failed to connect to server {}: {}", server_address, e);
                 continue;
             }
         };

--- a/libraries/tacacsrs_networking/src/helpers.rs
+++ b/libraries/tacacsrs_networking/src/helpers.rs
@@ -12,7 +12,7 @@ pub fn get_server_addresses(hostname : &str) -> anyhow::Result<Vec::<SocketAddr>
     };
 
     let server_address_list : Vec::<SocketAddr> = address.to_socket_addrs()?.collect();
-    return Ok(server_address_list);
+    Ok(server_address_list)
 }
 
 pub async fn connect_tcp(hostname : &str) -> anyhow::Result<tokio::net::TcpStream>
@@ -58,3 +58,64 @@ pub async fn connect_tls(stream : tokio::net::TcpStream, domain : &str) -> anyho
     let stream : tokio_rustls::client::TlsStream<tokio::net::TcpStream> = connector.connect(domain, stream).await?;
     Ok(stream)
 }
+
+
+// mod danger {
+//     use tokio_rustls::rustls;
+//     use tokio_rustls::rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+//     use rustls::client::danger::HandshakeSignatureValid;
+//     use rustls::crypto::{verify_tls13_signature, CryptoProvider};
+//     use rustls::DigitallySignedStruct;
+
+//     #[derive(Debug)]
+//     pub struct NoCertificateVerification(CryptoProvider);
+
+//     impl NoCertificateVerification {
+//         pub fn new(provider: CryptoProvider) -> Self {
+//             Self(provider)
+//         }
+//     }
+
+//     impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+//         fn verify_server_cert(
+//             &self,
+//             _end_entity: &CertificateDer<'_>,
+//             _intermediates: &[CertificateDer<'_>],
+//             _server_name: &ServerName<'_>,
+//             _ocsp: &[u8],
+//             _now: UnixTime,
+//         ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+//             println!("verify_server_cert");
+//             Ok(rustls::client::danger::ServerCertVerified::assertion())
+//         }
+
+//         fn verify_tls12_signature(
+//             &self,
+//             _message: &[u8],
+//             _cert: &CertificateDer<'_>,
+//             _dss: &DigitallySignedStruct,
+//         ) -> Result<HandshakeSignatureValid, rustls::Error> {
+//             Err(rustls::Error::General("TLS 1.2 not supported".to_string()))
+//         }
+
+//         fn verify_tls13_signature(
+//             &self,
+//             message: &[u8],
+//             cert: &CertificateDer<'_>,
+//             dss: &DigitallySignedStruct,
+//         ) -> Result<HandshakeSignatureValid, rustls::Error> {
+//             verify_tls13_signature(
+//                 message,
+//                 cert,
+//                 dss,
+//                 &self.0.signature_verification_algorithms,
+//             )
+//         }
+
+//         fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+//             self.0
+//                 .signature_verification_algorithms
+//                 .supported_schemes()
+//         }
+//     }
+// }

--- a/libraries/tacacsrs_networking/src/helpers.rs
+++ b/libraries/tacacsrs_networking/src/helpers.rs
@@ -1,0 +1,60 @@
+use std::{net::{SocketAddr, ToSocketAddrs}, sync::Arc};
+
+use tokio_rustls::{rustls, TlsConnector};
+
+
+pub fn get_server_addresses(hostname : &str) -> anyhow::Result<Vec::<SocketAddr>>
+{
+    let address = if hostname.contains(':') {
+        hostname.to_string()
+    } else {
+        format!("{}:{}", hostname, 49)
+    };
+
+    let server_address_list : Vec::<SocketAddr> = address.to_socket_addrs()?.collect();
+    return Ok(server_address_list);
+}
+
+pub async fn connect_tcp(hostname : &str) -> anyhow::Result<tokio::net::TcpStream>
+{
+    for server_address in get_server_addresses(hostname)?
+    {
+        match tokio::net::TcpStream::connect(server_address).await
+        {
+            Ok(stream) => return Ok(stream),
+            Err(e) => {
+                log::error!("Failed to connect to server: {}", e);
+                continue;
+            }
+        };
+    };
+
+    Err(anyhow::Error::msg("Failed to connect to any server"))
+}
+
+
+
+pub async fn connect_tls(stream : tokio::net::TcpStream, domain : &str) -> anyhow::Result<tokio_rustls::client::TlsStream<tokio::net::TcpStream>> {
+    // Only support TLS 1.3
+    let supported_tls_versions = vec![&rustls::version::TLS13];
+
+    // Empty certificate store
+    let root_cert_store = rustls::RootCertStore::empty();
+
+    // Default client config
+    let mut config = rustls::ClientConfig::builder_with_protocol_versions(supported_tls_versions.as_slice())
+        .with_root_certificates(root_cert_store)
+        .with_no_client_auth();
+
+    // Disable resumption
+    config.resumption = config.resumption.tls12_resumption(rustls::client::Tls12Resumption::Disabled);
+
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let domain = rustls::pki_types::ServerName::try_from(domain)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid dnsname"))?
+        .to_owned();
+
+    let stream : tokio_rustls::client::TlsStream<tokio::net::TcpStream> = connector.connect(domain, stream).await?;
+    Ok(stream)
+}

--- a/libraries/tacacsrs_networking/src/lib.rs
+++ b/libraries/tacacsrs_networking/src/lib.rs
@@ -3,3 +3,4 @@ pub mod session;
 pub mod sessions;
 pub mod duplex_channel;
 pub mod connection;
+pub mod tls_connection;

--- a/libraries/tacacsrs_networking/src/lib.rs
+++ b/libraries/tacacsrs_networking/src/lib.rs
@@ -4,3 +4,6 @@ pub mod sessions;
 pub mod duplex_channel;
 pub mod connection;
 pub mod tls_connection;
+pub mod tcp_connection;
+pub mod helpers;
+pub mod traits;

--- a/libraries/tacacsrs_networking/src/session.rs
+++ b/libraries/tacacsrs_networking/src/session.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use tokio::sync::RwLock;
 
 use crate::duplex_channel::DuplexChannel;
@@ -42,17 +40,15 @@ impl Session
         sequence_number
     }
 
-    pub async fn complete(self: &Arc<Self>)
+    pub async fn complete(&self)
     {
-        let self_clone = self.clone();
-        let mut session_complete_lock = self_clone.session_complete.write().await;
+        let mut session_complete_lock = self.session_complete.write().await;
         *session_complete_lock = true;
     }
 
-    pub async fn is_complete(self: &Arc<Self>) -> bool
+    pub async fn is_complete(&self) -> bool
     {
-        let self_clone = self.clone();
-        let session_complete_lock = self_clone.session_complete.read().await;
+        let session_complete_lock = self.session_complete.read().await;
         *session_complete_lock
     }
 }

--- a/libraries/tacacsrs_networking/src/sessions/accounting_session.rs
+++ b/libraries/tacacsrs_networking/src/sessions/accounting_session.rs
@@ -4,18 +4,17 @@ use tacacsrs_messages::packet::{Packet, PacketTrait};
 use tacacsrs_messages::traits::TacacsBodyTrait;
 
 use crate::session::Session;
-use std::sync::Arc;
 use tacacsrs_messages::accounting::{request::AccountingRequest, reply::AccountingReply};
 use tacacsrs_messages::enumerations::{TacacsMajorVersion, TacacsMinorVersion, TacacsType, TacacsFlags};
 
 #[async_trait]
 pub trait AccountingSessionTrait {
-    async fn send_accounting_request(self : &Arc<Self>, request: AccountingRequest) -> anyhow::Result<AccountingReply>;
+    async fn send_accounting_request(&self, request: AccountingRequest) -> anyhow::Result<AccountingReply>;
 }
 
 #[async_trait]
 impl AccountingSessionTrait for Session {
-    async fn send_accounting_request(self : &Arc<Self>, request: AccountingRequest) -> anyhow::Result<AccountingReply>
+    async fn send_accounting_request(&self, request: AccountingRequest) -> anyhow::Result<AccountingReply>
     {
         if self.is_complete().await {
             return Err(anyhow::Error::msg("Session is already complete"));

--- a/libraries/tacacsrs_networking/src/tcp_connection.rs
+++ b/libraries/tacacsrs_networking/src/tcp_connection.rs
@@ -15,7 +15,7 @@ use crate::traits::SessionCreationTrait;
 #[async_trait]
 pub trait TcpConnectionTrait : SessionCreationTrait
 {
-    fn new(obfuscation_key : Option<Vec<u8>>) -> Self;
+    fn new(obfuscation_key : Option<&[u8]>) -> Self;
     async fn run(self: &Arc<Self>, stream : TcpStream) -> anyhow::Result<()>;
 }
 
@@ -268,11 +268,14 @@ impl TcpConnection
 #[async_trait]
 impl TcpConnectionTrait for TcpConnection
 {
-    fn new(obfuscation_key : Option<Vec<u8>>) -> Self
+    fn new(obfuscation_key : Option<&[u8]>) -> Self
     {
         Self
         {
-            obfuscation_key,
+            obfuscation_key: match obfuscation_key {
+                Some(key) => Some(key.to_vec()),
+                None => Option::None
+            },
             connection: crate::connection::Connection::new()
         }
     }

--- a/libraries/tacacsrs_networking/src/tcp_connection.rs
+++ b/libraries/tacacsrs_networking/src/tcp_connection.rs
@@ -1,0 +1,308 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use tacacsrs_messages::enumerations::TacacsFlags;
+use tacacsrs_messages::packet::PacketTrait;
+use tacacsrs_messages::{header::Header, packet::Packet};
+
+use tacacsrs_messages::constants::TACACS_HEADER_LENGTH;
+use tokio::io::{AsyncWriteExt, AsyncReadExt};
+use tokio::net::TcpStream;
+use tokio::task;
+
+use crate::session::Session;
+use crate::traits::SessionCreationTrait;
+
+#[async_trait]
+pub trait TcpConnectionTrait : SessionCreationTrait
+{
+    fn new(obfuscation_key : Option<Vec<u8>>) -> Self;
+    async fn run(self: &Arc<Self>, stream : TcpStream) -> anyhow::Result<()>;
+}
+
+pub struct TcpConnection
+{
+    connection : crate::connection::Connection,
+    obfuscation_key : Option<Vec<u8>>,
+}
+
+impl TcpConnection
+{
+    async fn handle_connection(self: Arc<Self>, stream: TcpStream) -> anyhow::Result<()> {
+        let (reader, writer) = stream.into_split();
+
+        let write_task = {
+            let self_clone = Arc::clone(&self);
+            let receiver = self_clone.connection.receiver.lock().await.take().unwrap();
+
+            task::spawn(async move {
+                match TcpConnection::write_handler(receiver, writer, self_clone.obfuscation_key.clone()).await
+                {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        log::error!(
+                            target: "tacacsrs_networking::connection::handle_connection",
+                            "Write task failed with error: {}",
+                            e.to_string()
+                        );
+
+                        Err(e)
+                    }
+                }
+            })
+        };
+
+        let read_task = {
+            let self_clone = Arc::clone(&self);
+            task::spawn(async move {
+                match self_clone.read_handler(reader).await {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        log::error!(
+                            target: "tacacsrs_networking::connection::handle_connection",
+                            "Read task failed with error: {}",
+                            e.to_string()
+                        );
+
+                        Err(e)
+                    }
+                }
+            })
+        };
+
+        // Wait for both tasks to complete, and return an error if either task fails.
+        let (write_result, read_result) = tokio::try_join!(write_task, read_task)?;
+
+        // Set the can_accept_new_sessions flag to false, as the connection is now closed.
+        self.connection.disable_new_sessions().await;
+
+        // Bubble up any errors that occurred during the tasks.
+        write_result?;
+        read_result?;
+
+        // Return Ok if both tasks completed successfully.
+        Ok(())
+    }
+
+    async fn write_handler(mut receiver : tokio::sync::mpsc::Receiver<Packet>, mut writer: tokio::net::tcp::OwnedWriteHalf, obfuscation_key : Option<Vec<u8>>) -> anyhow::Result<()> {
+        loop {
+            let mut packet = match receiver.recv().await {
+                Some(packet) => packet,
+                None => {
+                    log::error!(
+                        target: "tacacsrs_networking::connection::write_handler",
+                        "No packet received from channel"
+                    );
+
+                    return Err(anyhow::Error::msg("No packet received"))
+                }
+            };
+
+            let session_id = packet.header().session_id;
+
+            log::info!(
+                target: "tacacsrs_networking::connection::write_handler",
+                "Received packet for session id {} to send to network",
+                session_id
+            );
+
+            let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
+            let mut did_obfuscate = false;
+            packet = match &obfuscation_key {
+                Some(key) => match is_packet_deobfuscated {
+                    true => {
+                        did_obfuscate = true;
+                        packet.to_obfuscated(key)
+                    },
+                    false => packet
+                },
+                None => packet
+            };
+
+            if did_obfuscate {
+                log::info!(
+                    target: "tacacsrs_networking::connection::write_handler",
+                    "Obfuscated packet for session id {}",
+                    session_id
+                );
+            }
+
+            let bytes = packet.to_bytes();
+            
+            writer.write_all(&bytes).await?;
+
+            log::info!(
+                target: "tacacsrs_networking::connection::write_handler",
+                "Sent packet for session id {} to network",
+                session_id
+            );
+        }
+    }
+
+    async fn read_handler(self: Arc<Self>, mut _reader: tokio::net::tcp::OwnedReadHalf) -> anyhow::Result<()> {
+        loop {
+            let mut header_buffer = [0_u8; TACACS_HEADER_LENGTH];
+
+            match _reader.read_exact(&mut header_buffer).await {
+                Ok(_) => (),
+                Err(e) => {
+                    log::error!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Failed to read header from network due to error: {}",
+                        e.to_string()
+                    );
+                    return Err(anyhow::Error::msg(e.to_string()))
+                }
+            };
+
+            let header = match Header::from_bytes(&header_buffer) {
+                Ok(header) => header,
+                Err(e) => {
+                    log::error!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Failed to parse header due to error: {}",
+                        e.to_string()
+                    );
+
+                    continue
+                }
+            };
+
+            let session_id = header.session_id;
+
+            log::info!(
+                target: "tacacsrs_networking::connection::read_handler",
+                "Received header with session id: {}. Loading body of length {}",
+                session_id, header.length
+            );
+
+            // Always read the body, regardless of the presence of the session. This is to prevent the 
+            // stream from getting out of sync.
+            let mut body_buffer = vec![0_u8; header.length as usize];
+            match _reader.read_exact(&mut body_buffer).await {
+                Ok(_) => (),
+                Err(e) => {
+                    log::error!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Failed to {} bytes from network for body session id {} due to error: {}",
+                        header.length, session_id, e.to_string()
+                    );
+
+                    return Err(anyhow::Error::msg(e.to_string()))
+                }
+            };
+
+            log::info!(
+                target: "tacacsrs_networking::connection::read_handler",
+                "Received body for session id: {}",
+                session_id
+            );
+
+            // Create a new packet and potentially deobfuscate it.
+            let mut packet =  match Packet::new(header, body_buffer) {
+                Ok(packet) => packet,
+                Err(e) => {
+                    log::error!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Could not load packet for session id {}. Failed with error: {}",
+                        session_id, e.to_string()
+                    );
+
+                    continue
+                }
+            };
+
+            let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
+            let mut did_deobfuscate = false;
+            packet = match &self.obfuscation_key {
+                Some(key) => match is_packet_deobfuscated {
+                    true => packet,
+                    false => {
+                        did_deobfuscate = true;
+                        packet.to_deobfuscated(key)
+                    },
+                },
+                None => packet
+            };
+
+            if did_deobfuscate {
+                log::info!(
+                    target: "tacacsrs_networking::connection::read_handler",
+                    "Deobfuscated packet for session id: {}",
+                    session_id
+                );
+            }
+
+            // Get a read lock on the duplex_channels dictionary and 
+            // find the appropriate channel to forward the packet to.
+            let duplex_channels = self.connection.duplex_channels.read().await;
+
+            match duplex_channels.get(&packet.header().session_id) {
+                Some(channel) => {
+                    log::info!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Found client channel for session id {}, forwarding packet",
+                        session_id
+                    );
+
+
+                    match channel.send(packet).await
+                    {
+                        Ok(_) => (),
+                        Err(e) => {
+                            log::warn!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Failed to send packet to client channel for session id: {} due to error: {}",
+                                session_id, e.to_string()
+                            );
+
+                            continue;
+                        }
+                    }
+                },
+                None => continue
+            };
+        }
+    }
+}
+
+#[async_trait]
+impl TcpConnectionTrait for TcpConnection
+{
+    fn new(obfuscation_key : Option<Vec<u8>>) -> Self
+    {
+        Self
+        {
+            obfuscation_key,
+            connection: crate::connection::Connection::new()
+        }
+    }
+
+    async fn run(self: &Arc<Self>, stream : TcpStream) -> anyhow::Result<()>
+    {
+        let self_clone = Arc::clone(&self);
+        task::spawn(async move {
+            self_clone.handle_connection(stream).await
+        });
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionCreationTrait for TcpConnection
+{
+    async fn can_create_sessions(self : Arc<Self>) -> bool
+    {
+        self.connection.can_create_sessions().await
+    }
+
+    async fn create_session(self : Arc<Self>) -> anyhow::Result<Session>
+    {
+        self.connection.create_session().await
+    }
+
+    async fn is_running(self : Arc<Self>) -> bool
+    {
+        self.connection.is_running().await
+    }
+}

--- a/libraries/tacacsrs_networking/src/tcp_connection.rs
+++ b/libraries/tacacsrs_networking/src/tcp_connection.rs
@@ -272,17 +272,14 @@ impl TcpConnectionTrait for TcpConnection
     {
         Self
         {
-            obfuscation_key: match obfuscation_key {
-                Some(key) => Some(key.to_vec()),
-                None => Option::None
-            },
-            connection: crate::connection::Connection::new()
+            connection: crate::connection::Connection::new(),
+            obfuscation_key: obfuscation_key.map(|key| key.to_vec())
         }
     }
 
     async fn run(self: &Arc<Self>, stream : TcpStream) -> anyhow::Result<()>
     {
-        let self_clone = Arc::clone(&self);
+        let self_clone = Arc::clone(self);
         task::spawn(async move {
             self_clone.handle_connection(stream).await
         });

--- a/libraries/tacacsrs_networking/src/tls_connection.rs
+++ b/libraries/tacacsrs_networking/src/tls_connection.rs
@@ -1,0 +1,331 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tacacsrs_messages::enumerations::TacacsFlags;
+use tacacsrs_messages::packet::PacketTrait;
+use tacacsrs_messages::{header::Header, packet::Packet};
+
+use tacacsrs_messages::constants::TACACS_HEADER_LENGTH;
+use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::net::TcpStream;
+use tokio::task::{self, JoinHandle};
+use tokio_rustls::client::TlsStream;
+
+use crate::{duplex_channel::DuplexChannel, session::Session};
+
+
+pub struct TlsConnection {
+    pub duplex_channels: RwLock<HashMap<u32, mpsc::Sender<Packet>>>,
+
+    sender: tokio::sync::mpsc::Sender<Packet>,
+    receiver: Mutex<Option<tokio::sync::mpsc::Receiver<Packet>>>,
+
+    run_task : RwLock<Option<JoinHandle<anyhow::Result<()>>>>,
+
+    can_accept_new_sessions: RwLock<bool>
+}
+
+
+impl TlsConnection
+{
+    // Setup the information required for the TCP connection,
+    // but do not connect.
+    pub fn new() -> Self
+    {
+        let (sender, receiver) = mpsc::channel::<Packet>(32);
+
+        Self
+        {
+            duplex_channels: HashMap::new().into(),
+            sender,
+            receiver: Some(receiver).into(),
+            run_task : None.into(),
+            can_accept_new_sessions: true.into()
+        }
+    }
+
+    pub async fn is_running(&self) -> bool
+    {
+        let run_task_lock = self.run_task.read().await;
+        run_task_lock.as_ref().map(|f| f.is_finished()).unwrap_or(false)
+    }
+
+    pub async fn connect(self: Arc<Self>, stream : TlsStream<TcpStream>) -> anyhow::Result<()>
+    {
+        let self_clone = Arc::clone(&self);
+        task::spawn(async move {
+            self_clone.handle_connection(stream).await
+        });
+
+        Ok(())
+    }
+
+    async fn handle_connection(self: Arc<Self>, stream: TlsStream<TcpStream>) -> anyhow::Result<()> {
+        let (mut reader, mut writer) = split(stream);
+
+        let write_task : JoinHandle<anyhow::Result<()>> = {
+            let self_clone = Arc::clone(&self);
+            let mut receiver = self_clone.receiver.lock().await.take().unwrap();
+
+            let write_future = async move {
+                let obfuscation_key = Some(b"demo".to_vec());
+
+                loop {
+                    let mut packet = match receiver.recv().await {
+                        Some(packet) => packet,
+                        None => {
+                            log::error!(
+                                target: "tacacsrs_networking::connection::write_handler",
+                                "No packet received from channel"
+                            );
+        
+                            break Err(anyhow::Error::msg("No packet received"))
+                        }
+                    };
+
+                    packet = packet.to_obfuscated(b"demo");
+        
+                    let session_id = packet.header().session_id;
+        
+                    log::info!(
+                        target: "tacacsrs_networking::connection::write_handler",
+                        "Received packet for session id {} to send to network",
+                        session_id
+                    );
+
+                    let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
+                    let mut did_obfuscate = false;
+                    packet = match &obfuscation_key {
+                        Some(key) => match is_packet_deobfuscated {
+                            true => {
+                                did_obfuscate = true;
+                                packet.to_obfuscated(key)
+                            },
+                            false => packet
+                        },
+                        None => packet
+                    };
+        
+                    if did_obfuscate {
+                        log::info!(
+                            target: "tacacsrs_networking::connection::write_handler",
+                            "Obfuscated packet for session id {}",
+                            session_id
+                        );
+                    }
+        
+                    let bytes = packet.to_bytes();
+                    
+                    writer.write_all(&bytes).await?;
+        
+                    log::info!(
+                        target: "tacacsrs_networking::connection::write_handler",
+                        "Sent packet for session id {} to network",
+                        session_id
+                    );
+                }
+            };
+
+            task::spawn(write_future)
+        };
+
+        let read_task : JoinHandle<anyhow::Result<()>> = {
+            let self_clone = Arc::clone(&self);
+            let read_task_future = async move {
+                let obfuscation_key = Some(b"demo".to_vec());
+
+                loop {
+                    let mut header_buffer = [0_u8; TACACS_HEADER_LENGTH];
+        
+                    match reader.read_exact(&mut header_buffer).await {
+                        Ok(_) => (),
+                        Err(e) => {
+                            log::error!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Failed to read header from network due to error: {}",
+                                e.to_string()
+                            );
+                            break Err(anyhow::Error::msg(e.to_string()))
+                        }
+                    };
+        
+                    let header = match Header::from_bytes(&header_buffer) {
+                        Ok(header) => header,
+                        Err(e) => {
+                            log::error!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Failed to parse header due to error: {}",
+                                e.to_string()
+                            );
+        
+                            continue
+                        }
+                    };
+        
+                    let session_id = header.session_id;
+        
+                    log::info!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Received header with session id: {}. Loading body of length {}",
+                        session_id, header.length
+                    );
+        
+                    // Always read the body, regardless of the presence of the session. This is to prevent the 
+                    // stream from getting out of sync.
+                    let mut body_buffer = vec![0_u8; header.length as usize];
+                    match reader.read_exact(&mut body_buffer).await {
+                        Ok(_) => (),
+                        Err(e) => {
+                            log::error!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Failed to {} bytes from network for body session id {} due to error: {}",
+                                header.length, session_id, e.to_string()
+                            );
+        
+                            break Err(anyhow::Error::msg(e.to_string()))
+                        }
+                    };
+        
+                    log::info!(
+                        target: "tacacsrs_networking::connection::read_handler",
+                        "Received body for session id: {}",
+                        session_id
+                    );
+        
+                    // Create a new packet and potentially deobfuscate it.
+                    let mut packet =  match Packet::new(header, body_buffer) {
+                        Ok(packet) => packet,
+                        Err(e) => {
+                            log::error!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Could not load packet for session id {}. Failed with error: {}",
+                                session_id, e.to_string()
+                            );
+        
+                            continue
+                        }
+                    };
+
+                    let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
+                    let mut did_deobfuscate = false;
+                    packet = match &obfuscation_key {
+                        Some(key) => match is_packet_deobfuscated {
+                            true => packet,
+                            false => {
+                                did_deobfuscate = true;
+                                packet.to_deobfuscated(key)
+                            },
+                        },
+                        None => packet
+                    };
+
+                    if did_deobfuscate {
+                        log::info!(
+                            target: "tacacsrs_networking::connection::read_handler",
+                            "Deobfuscated packet for session id: {}",
+                            session_id
+                        );
+                    }
+        
+                    // Get a read lock on the duplex_channels dictionary and 
+                    // find the appropriate channel to forward the packet to.
+                    let duplex_channels = self_clone.duplex_channels.read().await;
+        
+                    match duplex_channels.get(&packet.header().session_id) {
+                        Some(channel) => {
+                            log::info!(
+                                target: "tacacsrs_networking::connection::read_handler",
+                                "Found client channel for session id {}, forwarding packet",
+                                session_id
+                            );
+        
+                            match channel.send(packet).await
+                            {
+                                Ok(_) => (),
+                                Err(e) => {
+                                    log::warn!(
+                                        target: "tacacsrs_networking::connection::read_handler",
+                                        "Failed to send packet to client channel for session id: {} due to error: {}",
+                                        session_id, e.to_string()
+                                    );
+        
+                                    continue;
+                                }
+                            }
+                        },
+                        None => continue
+                    };
+                }
+            };
+
+            task::spawn(read_task_future)
+        };
+
+        // Wait for both tasks to complete, and return an error if either task fails.
+        let (write_result, read_result) = tokio::try_join!(write_task, read_task)?;
+        
+        // Set the can_accept_new_sessions flag to false, as the connection is now closed.
+        {
+            let mut can_accept_lock = self.can_accept_new_sessions.write().await;
+            *can_accept_lock = false;
+        }
+
+        // Bubble up any errors that occurred during the tasks.
+        write_result?;
+        read_result?;
+
+        // Return Ok if both tasks completed successfully.
+        Ok(())
+    }
+
+    async fn create_channel(&self) -> anyhow::Result<(DuplexChannel, u32)>
+    {
+        // create some channel where the send side connects to the internal MPSC receiver
+        // aka clone the sender and pass it to the DuplexChannel. Then create a new mpsc
+        // and associate that with the session id here inside the connection.
+        let (session_sender, session_receiver) = mpsc::channel::<Packet>(32);
+
+        let duplex_channel = DuplexChannel::new(session_receiver, self.sender.clone() );
+
+        // Generate new session id, regenerate session id if it already exists
+        let mut session_id = rand::random::<u32>();
+
+        // get lock on duplex_channels and then insert the new session id
+        {
+            let mut duplex_channels = self.duplex_channels.write().await;
+
+            while duplex_channels.contains_key(&session_id)
+            {
+                session_id = rand::random::<u32>();
+            }
+
+            duplex_channels.insert(session_id, session_sender);
+        }
+
+        Ok((duplex_channel, session_id))
+    }
+
+    pub async fn can_create_sessions(&self) -> bool
+    {
+        let can_accept_lock = self.can_accept_new_sessions.read().await;
+        *can_accept_lock
+    }
+
+    pub async fn create_session(&self) -> anyhow::Result<Session>
+    {
+        if !self.can_create_sessions().await
+        {
+            return Err(anyhow::Error::msg("Connection is not accepting new sessions"));
+        }
+
+        let (duplex_channel, session_id) = self.create_channel().await?;
+
+        log::info!(
+            target: "tacacsrs_networking::connection::create_session",
+            "Created session with id: {}",
+            session_id
+        );
+
+        Ok(Session::new(session_id, duplex_channel))
+    }
+}

--- a/libraries/tacacsrs_networking/src/tls_connection.rs
+++ b/libraries/tacacsrs_networking/src/tls_connection.rs
@@ -52,8 +52,6 @@ impl TlsConnection {
                         }
                     };
 
-                    packet = packet.to_obfuscated(b"demo");
-        
                     let session_id = packet.header().session_id;
         
                     log::info!(
@@ -101,7 +99,6 @@ impl TlsConnection {
         let read_task : JoinHandle<anyhow::Result<()>> = {
             let self_clone = Arc::clone(&self);
             let read_task_future = async move {
-                let obfuscation_key = Some(b"demo".to_vec());
 
                 loop {
                     let mut header_buffer = [0_u8; TACACS_HEADER_LENGTH];
@@ -177,7 +174,7 @@ impl TlsConnection {
 
                     let is_packet_deobfuscated = packet.header().flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG);
                     let mut did_deobfuscate = false;
-                    packet = match &obfuscation_key {
+                    packet = match &self_clone.obfuscation_key {
                         Some(key) => match is_packet_deobfuscated {
                             true => packet,
                             false => {

--- a/libraries/tacacsrs_networking/src/traits.rs
+++ b/libraries/tacacsrs_networking/src/traits.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use crate::session::Session;
+
+
+#[async_trait]
+pub trait SessionCreationTrait {
+    async fn can_create_sessions(self : Arc<Self>) -> bool;
+    async fn create_session(self : Arc<Self>) -> anyhow::Result<Session>;
+    async fn is_running(self : Arc<Self>) -> bool;
+}


### PR DESCRIPTION
This pull request adds TLS support and includes several changes aimed at refactoring and improving the codebase, particularly around the `tacacsrs` library. The most important changes involve simplifying the usage of session and connection handling, updating dependencies, and cleaning up test code.

### Refactoring and Simplification:

* [`executables/tacon/src/commands/accounting.rs`](diffhunk://#diff-414a0df327dc295065fa581c71c7180c9b8b9328d6b15671f59adbcfa9451e8bL1-R8): Simplified the `send_accounting_request` function by removing the need for cloning the session and using direct session calls. [[1]](diffhunk://#diff-414a0df327dc295065fa581c71c7180c9b8b9328d6b15671f59adbcfa9451e8bL1-R8) [[2]](diffhunk://#diff-414a0df327dc295065fa581c71c7180c9b8b9328d6b15671f59adbcfa9451e8bL42-R37)
* [`executables/tacon/src/main.rs`](diffhunk://#diff-e97868c2afc49687563a10dd2d24df1819509218b434215fe4744a99b325f169L3-L13): Refactored the connection setup to use the new `connect_tcp` helper function and streamlined session creation. Removed the `resolve_hostname` function and related code. [[1]](diffhunk://#diff-e97868c2afc49687563a10dd2d24df1819509218b434215fe4744a99b325f169L3-L13) [[2]](diffhunk://#diff-e97868c2afc49687563a10dd2d24df1819509218b434215fe4744a99b325f169L69-L78) [[3]](diffhunk://#diff-e97868c2afc49687563a10dd2d24df1819509218b434215fe4744a99b325f169L94-R91)
* [`libraries/tacacsrs_networking/examples/multiple_transactions.rs`](diffhunk://#diff-edc3ad45f95031350523b04985c2ca853b431d2034884a5bc4a378c5c655d3efL2-R78): Updated the example to use the new connection and session handling approach, including error handling improvements and session creation in a more scalable manner. [[1]](diffhunk://#diff-edc3ad45f95031350523b04985c2ca853b431d2034884a5bc4a378c5c655d3efL2-R78) [[2]](diffhunk://#diff-edc3ad45f95031350523b04985c2ca853b431d2034884a5bc4a378c5c655d3efL83-R106)

### Dependency Updates:

* [`libraries/tacacsrs_networking/Cargo.toml`](diffhunk://#diff-ca5f04bdd8ede86d8065c74a74dbaf2d8b6dd8006ddacff3b6db9643fd18f691R13-R19): Added new dependencies such as `tokio-rustls`, `argh`, `rustls-pemfile`, and `webpki-roots` to support new features and improve security.

### Test Code Improvements:

* [`libraries/tacacsrs_messages/src/accounting/request.rs`](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L340-R340): Simplified test assertions by directly matching results and using more concise error handling. [[1]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L340-R340) [[2]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L354-R354) [[3]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L369-R369) [[4]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L384-R384) [[5]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L399-R399) [[6]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L414-R414) [[7]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L429-R429) [[8]](diffhunk://#diff-2dc57e7258a2fe0e08ceb6cabd9c1d10c0e46f391d210438309f3a34d5404f00L479-R479)
* [`libraries/tacacsrs_messages/src/header.rs`](diffhunk://#diff-c7ebc73451cff60f8f0a8fee0d6b0d91fcb7fed8a5cd7228c51855a846d88ce7L114-R116): Refined test code by removing redundant type casts and using more idiomatic Rust patterns. [[1]](diffhunk://#diff-c7ebc73451cff60f8f0a8fee0d6b0d91fcb7fed8a5cd7228c51855a846d88ce7L114-R116) [[2]](diffhunk://#diff-c7ebc73451cff60f8f0a8fee0d6b0d91fcb7fed8a5cd7228c51855a846d88ce7L129-R133) [[3]](diffhunk://#diff-c7ebc73451cff60f8f0a8fee0d6b0d91fcb7fed8a5cd7228c51855a846d88ce7L148-R153) [[4]](diffhunk://#diff-c7ebc73451cff60f8f0a8fee0d6b0d91fcb7fed8a5cd7228c51855a846d88ce7L162-R162)
* [`libraries/tacacsrs_messages/src/obfuscation.rs`](diffhunk://#diff-17bc571541d4f365c21dd628dba1539063afd9432aefae84dff7699bac94db0dL125-R134): Improved test readability by using assertion macros and simplifying function calls.