### PR TITLE
Add session testing

### DIFF
--- a/.github/workflows/pullrequest_workflow.yml
+++ b/.github/workflows/pullrequest_workflow.yml
@@ -12,23 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: '${{ runner.os }}-cargo-index-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -37,24 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: '${{ runner.os }}-cargo-index-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
           components: 'rustfmt, clippy'
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -69,23 +43,12 @@ jobs:
           - os: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: '${{ runner.os }}-cargo-index-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -110,23 +73,12 @@ jobs:
       - uses: actions/checkout@master
         with:
           lfs: true
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: '${{ runner.os }}-cargo-registry-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: '${{ runner.os }}-cargo-index-${{ hashFiles(''**/Cargo.lock'') }}'
-      - uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/libraries/tacacsrs_networking/src/duplex_channel.rs
+++ b/libraries/tacacsrs_networking/src/duplex_channel.rs
@@ -18,4 +18,15 @@ impl DuplexChannel
             receiver: session_receiver.into(),
         }
     }
+
+    pub async fn sender_closed(&self) -> bool
+    {
+        self.sender.is_closed()
+    }
+
+    pub async fn receiver_closed(&self) -> bool
+    {
+        let reader_lock = self.receiver.read().await;
+        reader_lock.is_closed()
+    }
 }

--- a/libraries/tacacsrs_networking/src/session.rs
+++ b/libraries/tacacsrs_networking/src/session.rs
@@ -48,7 +48,84 @@ impl Session
 
     pub async fn is_complete(&self) -> bool
     {
+        if self.duplex_channel.sender_closed().await
+        {
+            return true;
+        }
+
+        if self.duplex_channel.receiver_closed().await
+        {
+            return true;
+        }
+
         let session_complete_lock = self.session_complete.read().await;
         *session_complete_lock
+    }
+}
+
+
+#[cfg(test)]
+mod tests
+{
+    use super::*;
+    use crate::duplex_channel::DuplexChannel;
+    use tacacsrs_messages::packet::Packet;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn test_session()
+    {
+        let (network_sender, _network_receiver) = mpsc::channel::<Packet>(32);
+        let (_client_sender, client_receiver) = mpsc::channel::<Packet>(32);
+        let duplex_channel = DuplexChannel::new(client_receiver, network_sender);
+
+        let session = Session::new(1, duplex_channel);
+
+        assert_eq!(session.session_id(), 1);
+        assert_eq!(session.is_complete().await, false);
+
+        session.complete().await;
+
+        assert_eq!(session.is_complete().await, true);
+    }
+
+    #[tokio::test]
+    async fn test_sequence_number()
+    {
+        let (network_sender, _network_receiver) = mpsc::channel::<Packet>(32);
+        let (_client_sender, client_receiver) = mpsc::channel::<Packet>(32);
+        let duplex_channel = DuplexChannel::new(client_receiver, network_sender);
+
+        let session = Session::new(1, duplex_channel);
+
+        assert_eq!(session.next_sequence_number().await, 1);
+        assert_eq!(session.next_sequence_number().await, 3);
+        assert_eq!(session.next_sequence_number().await, 5);
+
+        assert_eq!(session.is_complete().await, false);
+    }
+
+    #[tokio::test]
+    async fn test_is_complete_network_closed()
+    {
+        let (network_sender, _network_receiver) = mpsc::channel::<Packet>(32);
+        let (_client_sender, client_receiver) = mpsc::channel::<Packet>(32);
+        let duplex_channel = DuplexChannel::new(client_receiver, network_sender);
+
+        let session = Session::new(1, duplex_channel);
+        assert_eq!(session.is_complete().await, false);
+
+        // Close the client sender, this should propagate to the session
+        drop(_client_sender);
+
+        // session is complete because the client sender is closed
+        assert_eq!(session.is_complete().await, true);
+
+        // the client sender is still open because it'll be used by many sessions
+        assert_eq!(_network_receiver.is_closed(), false);
+        assert_eq!(session.duplex_channel.sender_closed().await, false);
+
+        // the client receiver is closed
+        assert_eq!(session.duplex_channel.receiver_closed().await, true);
     }
 }

--- a/libraries/tacacsrs_networking/src/sessions/accounting_session.rs
+++ b/libraries/tacacsrs_networking/src/sessions/accounting_session.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
+use log::info;
 use tacacsrs_messages::header::Header;
 use tacacsrs_messages::packet::{Packet, PacketTrait};
 use tacacsrs_messages::traits::TacacsBodyTrait;
-
-use crate::session::Session;
 use tacacsrs_messages::accounting::{request::AccountingRequest, reply::AccountingReply};
 use tacacsrs_messages::enumerations::{TacacsMajorVersion, TacacsMinorVersion, TacacsType, TacacsFlags};
+
+use crate::session::Session;
 
 #[async_trait]
 pub trait AccountingSessionTrait {
@@ -33,6 +34,12 @@ impl AccountingSessionTrait for Session {
             session_id : self.session_id(),
             length : data.len() as u32
         }, data)?;
+
+        info!(
+            target: "tacacsrs_networking::sessions::accounting_session",
+            "Sending Accounting Request with sequence number {} for session {}",
+            sequence_number, self.session_id()
+        );
         
         self.duplex_channel.sender.send(packet).await?;
 
@@ -55,5 +62,74 @@ impl AccountingSessionTrait for Session {
         );
 
         Ok(reply)
+    }
+}
+
+
+
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use tacacsrs_messages::enumerations::*;
+
+    use crate::traits::SessionManagementTrait;
+    use test_log::test;
+
+    
+    #[test(tokio::test)]
+    async fn test_send_accounting_request() -> anyhow::Result<()> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let tacacs_connection = Arc::new(
+            crate::mock_connection::MockConnection::new()
+        );
+        tacacs_connection.run().await?;
+    
+        let session = tacacs_connection.create_session().await?;
+    
+        let accounting_request = AccountingRequest
+        {
+            flags: TacacsAccountingFlags::START,
+            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
+            priv_lvl: 0,
+            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
+            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcNone,
+            user: "admin".to_string(),
+            port: "test".to_string(),
+            rem_address: "1.1.1.1".to_string(),
+            args: vec![
+                "service=shell".to_string(),
+                "task_id=123".to_string(),
+                "cmd=test".to_string()
+            ],
+        };
+    
+        let accounting_reply = AccountingReply
+        {
+            status: TacacsAccountingStatus::TacPlusAcctStatusSuccess,
+            server_msg: "Test".to_string(),
+            data: "".to_string(),
+        };
+    
+        tacacs_connection.add_accounting_reply(&session, 2, &accounting_reply).await?;
+        
+        let reply = session.send_accounting_request(accounting_request).await?;
+
+        assert_eq!(reply.status, TacacsAccountingStatus::TacPlusAcctStatusSuccess);
+
+
+        let requests = tacacs_connection.get_requests_for_session(session.session_id).await?;
+        assert_eq!(requests.len(), 1, "The number of requests for the session was not as expected");
+
+        let replies = tacacs_connection.get_replies_for_session(session.session_id).await?;
+        assert_eq!(replies.len(), 0, "There was replies registered to session when they should have all been removed");
+    
+    
+        Ok(())
     }
 }


### PR DESCRIPTION
This pull request includes significant updates to the CI workflow and enhancements to the `DuplexChannel` and `Session` implementations in the `tacacsrs_networking` library. The most important changes streamline the caching mechanism in the GitHub Actions workflow and add new functionality and tests for session handling.

### GitHub Actions Workflow Updates:
* Replaced multiple `actions/cache@v1` steps with a single `Swatinem/rust-cache@v2` step to simplify caching in the `.github/workflows/pullrequest_workflow.yml` file. [[1]](diffhunk://#diff-338afb30146afe995ca229637d3af4241c1b518641b3fe05c070515cf64f9f94L15-R16) [[2]](diffhunk://#diff-338afb30146afe995ca229637d3af4241c1b518641b3fe05c070515cf64f9f94L40-R31) [[3]](diffhunk://#diff-338afb30146afe995ca229637d3af4241c1b518641b3fe05c070515cf64f9f94L72-R51) [[4]](diffhunk://#diff-338afb30146afe995ca229637d3af4241c1b518641b3fe05c070515cf64f9f94L113-R81)

### `DuplexChannel` Enhancements:
* Added `sender_closed` and `receiver_closed` methods to check if the sender or receiver channels are closed. (`libraries/tacacsrs_networking/src/duplex_channel.rs`)

### `Session` Enhancements:
* Updated the `is_complete` method to check if the sender or receiver channels are closed. (`libraries/tacacsrs_networking/src/session.rs`)
* Added comprehensive tests for session creation, sequence number handling, and completion status. (`libraries/tacacsrs_networking/src/session.rs`)

### Logging and Tests in `AccountingSession`:
* Added logging for sending accounting requests and included tests for accounting request handling. (`libraries/tacacsrs_networking/src/sessions/accounting_session.rs`) [[1]](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69R2-R10) [[2]](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69R38-R43) [[3]](diffhunk://#diff-4d9cff9999bea675537af87defc9c0aa5b70976afc0dcef5c1195862c05fbb69R67-R135)