### PR TITLE
Add example compose config

### DIFF
--- a/lde/containers/compose.yml
+++ b/lde/containers/compose.yml
@@ -1,0 +1,30 @@
+services:
+  tacplus:
+    build:
+      context: https://github.com/lfkeitel/docker-tacacs-plus.git
+      args:
+        SRC_VERSION: '202104181633'
+        SRC_HASH: 'F2695A7CC908E03BAB8FFB0A84603A0AD103B4532CC84900624899CC1C32E4AB'
+    image: 'tac_plus:ubuntu'
+    restart: unless-stopped
+    environment:
+      - TZ=Australia/Brisbane
+      - TAC_PLUS_ADDITIONAL_ARGS="-d 1"
+    ports:
+      - '49:49'
+    volumes:
+      - ./tac_plus.cfg:/etc/tac_plus/tac_plus.cfg
+
+  tlsrelay:
+    build:
+      dockerfile: ./relay.dockerfile
+    image: 'tcprelay:ubuntu'
+    restart: unless-stopped
+    depends_on:
+      - tacplus
+    environment:
+      - TZ=Australia/Brisbane
+    ports:
+      - '449:449'
+    volumes:
+      - ./tac_relay.cfg:/usr/local/etc/tcprelay.cfg

--- a/lde/containers/relay.dockerfile
+++ b/lde/containers/relay.dockerfile
@@ -1,0 +1,37 @@
+# start with Alpine Linux
+FROM alpine:latest
+
+# system setup with all requirements
+RUN apk add --no-cache \
+        build-base \
+        c-ares-dev \
+        curl \
+        curl-dev \
+        freeradius-client-dev \
+        libretls-dev \
+        linux-pam-dev \
+        openssl-dev \
+        pcre2-dev \
+        perl \
+        perl-authen-radius \
+        perl-ldap \
+        perl-net-ip \
+        perl-sys-syslog \
+    && echo "! installation is finished !"
+
+# download and install MarcJHuber event-driven-servers / tac_plus-ng repository
+RUN wget https://github.com/MarcJHuber/event-driven-servers/archive/refs/heads/master.zip -O event-driven-servers-master.zip && \
+    unzip event-driven-servers-master.zip && \
+    cd event-driven-servers-master && \
+    ./configure && \
+    make && \
+    make install && \
+    # copy sample configuration file
+    cp /event-driven-servers-master/tcprelay/sample/* /usr/local/etc && \
+    echo "! service setup successful !"
+
+# expose port
+EXPOSE 449
+
+# run tac_plus-ng
+CMD ["/usr/local/sbin/tcprelay", "-d", "1", "/usr/local/etc/tcprelay.cfg"]

--- a/lde/containers/tac_relay.cfg
+++ b/lde/containers/tac_relay.cfg
@@ -1,0 +1,11 @@
+id = spawnd { listen = { address = 0.0.0.0 port = 449 tls = yes }
+        single process = yes
+        spawn { instances max = 1 }
+        background = no
+}
+id = tcprelay {
+        tls cert-file = /usr/local/etc/demo.pem
+        tls key-file = /usr/local/etc/demo.key
+        tls passphrase = demo
+        remote = { address = 192.168.1.32 port = 49 }
+}


### PR DESCRIPTION
This pull request introduces new services and configurations to the `lde` container setup. The changes include adding two new services, `tacplus` and `tlsrelay`, along with their respective Docker configurations and a sample configuration file for the `tlsrelay` service.

New Services and Docker Configurations:

* [`lde/containers/compose.yml`](diffhunk://#diff-355a4f9964521afa6beb39fa34a9d47f95d97571caa92d2ff348a5e3913db843R1-R30): Added two new services, `tacplus` and `tlsrelay`, with their respective build contexts, images, environment variables, and volume mappings. The `tlsrelay` service is dependent on the `tacplus` service.
* [`lde/containers/relay.dockerfile`](diffhunk://#diff-e993afed16c8bc09d5e623cedf788da138ca3529b57bdbf15adbcbe2b7427270R1-R37): Created a new Dockerfile for the `tlsrelay` service, starting from an Alpine Linux base image and installing necessary dependencies and the `tcprelay` application.

Configuration Files:

* [`lde/containers/tac_relay.cfg`](diffhunk://#diff-b322f19b686674b04213e0b507a2b878f97814703541b99c59fa12627dae5aa2R1-R11): Added a sample configuration file for the `tlsrelay` service, specifying the TLS settings and remote address for the relay.