### PR TITLE
Update changelog generation and enhance version computation

### DIFF
--- a/.github/steps/compute-versions/action.yml
+++ b/.github/steps/compute-versions/action.yml
@@ -31,6 +31,9 @@ outputs:
   calver_tag:
     description: 'CalVer tag for the executable (empty if unchanged)'
     value: ${{ steps.compute.outputs.calver_tag }}
+  previous_calver_tag:
+    description: 'Previous CalVer tag used as baseline (empty if first release)'
+    value: ${{ steps.compute.outputs.previous_calver_tag }}
 
 runs:
   using: composite

--- a/.github/steps/compute-versions/compute_versions.py
+++ b/.github/steps/compute-versions/compute_versions.py
@@ -48,6 +48,7 @@ class VersionResult:
     version: str
     tag: str | None = None  # non-None when a new tag should be created
     reason: str = ""
+    previous_tag: str | None = None  # the tag this release is based on
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +292,7 @@ def compute_calver(
         version=version,
         tag=tag,
         reason="calver",
+        previous_tag=latest,
     )
 
 
@@ -528,11 +530,13 @@ def compute_all_versions(
         print(f"  {r.name}: {r.version} ({r.reason})")
 
     calver_tag = ""
+    previous_calver_tag = ""
     if calver_result is not None:
         versions[calver_result.name] = calver_result.version
         if calver_result.tag:
             new_tags.append(calver_result.tag)
             calver_tag = calver_result.tag
+            previous_calver_tag = calver_result.previous_tag or ""
         print(f"  {calver_result.name}: {calver_result.version} ({calver_result.reason})")
     else:
         print(f"  {binary_name}: unchanged (no calver)")
@@ -542,6 +546,7 @@ def compute_all_versions(
         "new_tags": new_tags,
         "has_release": len(new_tags) > 0,
         "calver_tag": calver_tag,
+        "previous_calver_tag": previous_calver_tag,
     }
 
 
@@ -583,6 +588,7 @@ def main() -> None:
     write_github_output("new_tags", json.dumps(result["new_tags"]))
     write_github_output("has_release", json.dumps(result["has_release"]))
     write_github_output("calver_tag", result["calver_tag"])
+    write_github_output("previous_calver_tag", result["previous_calver_tag"])
 
 
 if __name__ == "__main__":

--- a/.github/steps/inject-versions/action.yml
+++ b/.github/steps/inject-versions/action.yml
@@ -36,20 +36,3 @@ runs:
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" "$CARGO_TOML"
           echo "  ${CRATE} → ${VERSION}  (${CARGO_TOML})"
         done
-
-    - name: Update debian/changelog if present
-      shell: bash
-      run: |
-        VERSIONS='${{ inputs.versions }}'
-
-        if [ -z "$VERSIONS" ] || [ "$VERSIONS" = "{}" ]; then
-          exit 0
-        fi
-
-        echo "$VERSIONS" | jq -r 'to_entries[] | "\(.key)\t\(.value)"' | tr -d '\r' | while IFS=$'\t' read -r CRATE VERSION; do
-          CHANGELOG="executables/${CRATE}/debian/changelog"
-          if [ -f "$CHANGELOG" ]; then
-            sed -i "1s/([^)]*)/($VERSION)/" "$CHANGELOG"
-            echo "  ${CRATE} debian/changelog → ${VERSION}"
-          fi
-        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       calver-tag: ${{ steps.compute.outputs.calver_tag }}
       has-release: ${{ steps.compute.outputs.has_release }}
       new-tags: ${{ steps.compute.outputs.new_tags }}
+      previous-calver-tag: ${{ steps.compute.outputs.previous_calver_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -117,6 +118,7 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          previous_tag: ${{ needs.compute-versions.outputs.previous-calver-tag }}
           files: |
             artifacts/*
         env:

--- a/.github/workflows/reusable-deb.yml
+++ b/.github/workflows/reusable-deb.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Inject versions
         uses: ./.github/steps/inject-versions
@@ -85,11 +87,73 @@ jobs:
             exit 1
           fi
           echo "Found man page at: $MAN_PAGE"
-          # Copy to debian directory and compress
           cp "$MAN_PAGE" executables/${{ inputs.package-name }}/debian/${{ inputs.package-name }}.1
-          cd executables/${{ inputs.package-name }}/debian
+
+          # Generate full debian changelog from git tag history
+          PKG="${{ inputs.package-name }}"
+          VERSIONS='${{ inputs.versions }}'
+          VERSION=$(echo "$VERSIONS" | jq -r --arg pkg "$PKG" '.[$pkg] // "0.0.0-dev"' | tr -d '\r')
+          TAG_PREFIX="${PKG}-"
+          MAINTAINER="AuthScaffold <support@authscaffold.com>"
+          PKG_DIR="executables/${PKG}"
+          CHANGELOG="${PKG_DIR}/debian/changelog"
+
+          # Collect all CalVer tags for this package, oldest first
+          mapfile -t TAGS < <(git tag --list "${TAG_PREFIX}*" --sort=v:refname)
+
+          > "$CHANGELOG"
+
+          # --- Current (unreleased) stanza: commits since last tag ---
+          if [ ${#TAGS[@]} -gt 0 ]; then
+            LAST_TAG="${TAGS[-1]}"
+            COMMITS=$(git log --pretty=format:"  * %s" "${LAST_TAG}..HEAD" -- "${PKG_DIR}")
+          else
+            COMMITS=$(git log --pretty=format:"  * %s" -- "${PKG_DIR}")
+          fi
+          if [ -z "$COMMITS" ]; then
+            COMMITS="  * Release ${VERSION}"
+          fi
+          {
+            echo "${PKG} (${VERSION}) stable; urgency=medium"
+            echo ""
+            echo "$COMMITS"
+            echo ""
+            echo " -- ${MAINTAINER}  $(date -u -R)"
+          } >> "$CHANGELOG"
+
+          # --- Historical stanzas from tags, newest first ---
+          for (( i=${#TAGS[@]}-1; i>=0; i-- )); do
+            TAG="${TAGS[$i]}"
+            TAG_VERSION="${TAG#${TAG_PREFIX}}"
+            TAG_DATE=$(git log -1 --format="%aD" "$TAG")
+
+            if [ $i -gt 0 ]; then
+              PREV="${TAGS[$((i-1))]}"
+              COMMITS=$(git log --pretty=format:"  * %s" "${PREV}..${TAG}" -- "${PKG_DIR}")
+            else
+              COMMITS=$(git log --pretty=format:"  * %s" "${TAG}" -- "${PKG_DIR}")
+            fi
+
+            if [ -z "$COMMITS" ]; then
+              COMMITS="  * Release ${TAG_VERSION}"
+            fi
+
+            {
+              echo ""
+              echo "${PKG} (${TAG_VERSION}) stable; urgency=medium"
+              echo ""
+              echo "$COMMITS"
+              echo ""
+              echo " -- ${MAINTAINER}  ${TAG_DATE}"
+            } >> "$CHANGELOG"
+          done
+
+          echo "Generated changelog ($(grep -c '^${PKG} ' "$CHANGELOG" || true) stanzas):"
+          cat "$CHANGELOG"
+
+          cd "${PKG_DIR}/debian"
           gzip -9 -n -c changelog > changelog.gz
-          gzip -9 -n -c ${{ inputs.package-name }}.1 > ${{ inputs.package-name }}.1.gz
+          gzip -9 -n -c ${PKG}.1 > ${PKG}.1.gz
 
       - name: Generate .deb package
         run: cargo deb --package ${{ inputs.package-name }} --no-build --dbgsym

--- a/executables/tacon/debian/changelog
+++ b/executables/tacon/debian/changelog
@@ -1,9 +1,0 @@
-tacon (2026.416.0) stable; urgency=medium
-
-  * Migrate to CalVer versioning (YYYY.MMDD.BUILD)
-  * TACACS+ client CLI for authentication, authorization, and accounting
-  * Support for traditional TACACS+ with obfuscation
-  * Support for TACACS+ over TLS 1.3
-  * Batch mode for multiple requests
-
- -- AuthScaffold <support@authscaffold.com>  Thu, 16 Apr 2026 00:00:00 +0000


### PR DESCRIPTION
This pull request introduces improvements to version tracking and changelog generation in the release automation. It adds support for tracking the previous CalVer tag, enhances the GitHub Actions workflow to pass this information between steps, and replaces the static Debian changelog with an automatically generated one based on Git tag history and commit messages. This ensures more accurate, up-to-date release notes and changelogs for Debian packages.

**Version tracking enhancements:**

* Added a `previous_calver_tag` output to the compute-versions step, including it in the workflow outputs and making it available to downstream steps and jobs (`.github/steps/compute-versions/action.yml`, `.github/steps/compute-versions/compute_versions.py`, `.github/workflows/ci.yml`). [[1]](diffhunk://#diff-2d76b6ec723eff418557c378436113896685118ccd79cd5860493e43f7110987R34-R36) [[2]](diffhunk://#diff-8a9c4391e63d01d443be8f7abb883e45e3c3f774ec9efff01809d4eee78f18fcR51) [[3]](diffhunk://#diff-8a9c4391e63d01d443be8f7abb883e45e3c3f774ec9efff01809d4eee78f18fcR295) [[4]](diffhunk://#diff-8a9c4391e63d01d443be8f7abb883e45e3c3f774ec9efff01809d4eee78f18fcR533-R539) [[5]](diffhunk://#diff-8a9c4391e63d01d443be8f7abb883e45e3c3f774ec9efff01809d4eee78f18fcR549) [[6]](diffhunk://#diff-8a9c4391e63d01d443be8f7abb883e45e3c3f774ec9efff01809d4eee78f18fcR591) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR27) [[8]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR121)

**Changelog generation improvements:**

* Replaced the static `debian/changelog` with a script that generates the changelog from Git tag history and commit messages, ensuring all releases and their changes are accurately reflected (`.github/workflows/reusable-deb.yml`, `executables/tacon/debian/changelog`). [[1]](diffhunk://#diff-f737cf1ffd4af45b8b048358a14d957f6f1e184d30db70d756519ab790bc89f9L88-R156) [[2]](diffhunk://#diff-cbab61b76984584dabb0623502bbeb9bc05daa3dee269dfa9fb0e347fb7d1f71L1-L9)
* Ensured the workflow fetches the full Git history to support changelog generation (`.github/workflows/reusable-deb.yml`).

**Workflow simplification:**

* Removed the previous step that only updated the top stanza of the Debian changelog, as it's now fully generated from history (`.github/steps/inject-versions/action.yml`).

These changes improve the traceability and automation of the release process, especially for Debian package builds.