### PR TITLE
Improve CI workflow and test configurations for better coverage

### DIFF
--- a/.github/steps/generate-coverage/action.yml
+++ b/.github/steps/generate-coverage/action.yml
@@ -21,10 +21,30 @@ runs:
     - name: Generate text summary
       shell: bash
       run: |
+        JSON=$(cargo llvm-cov report --json 2>/dev/null)
+
+        # Extract totals
+        TOTAL_LINES=$(echo "$JSON" | jq -r '.data[0].totals.lines.percent | . * 100 | round | . / 100')
+        TOTAL_FUNCTIONS=$(echo "$JSON" | jq -r '.data[0].totals.functions.percent | . * 100 | round | . / 100')
+        TOTAL_REGIONS=$(echo "$JSON" | jq -r '.data[0].totals.regions.percent | . * 100 | round | . / 100')
+        TOTAL_LINES_COVERED=$(echo "$JSON" | jq -r '.data[0].totals.lines.covered')
+        TOTAL_LINES_COUNT=$(echo "$JSON" | jq -r '.data[0].totals.lines.count')
+
         echo '## Code Coverage' >> "$GITHUB_STEP_SUMMARY"
-        echo '```' >> "$GITHUB_STEP_SUMMARY"
-        cargo llvm-cov report --lcov --summary-only 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
-        echo '```' >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "**Total: ${TOTAL_LINES}% lines** (${TOTAL_LINES_COVERED}/${TOTAL_LINES_COUNT}) | ${TOTAL_FUNCTIONS}% functions | ${TOTAL_REGIONS}% regions" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo '| File | Lines | Line % | Functions | Fn % | Regions | Region % |' >> "$GITHUB_STEP_SUMMARY"
+        echo '|------|------:|-------:|----------:|-----:|--------:|---------:|' >> "$GITHUB_STEP_SUMMARY"
+        echo "$JSON" | jq -r '
+          .data[0].files[]
+          | select(.summary.lines.count > 0)
+          | "\(.filename | split("/") | .[-3:] | join("/")) | \(.summary.lines.covered)/\(.summary.lines.count) | \(.summary.lines.percent | . * 100 | round | . / 100)% | \(.summary.functions.covered)/\(.summary.functions.count) | \(.summary.functions.percent | . * 100 | round | . / 100)% | \(.summary.regions.covered)/\(.summary.regions.count) | \(.summary.regions.percent | . * 100 | round | . / 100)%"
+        ' | sort | while IFS= read -r line; do
+          echo "| ${line} |" >> "$GITHUB_STEP_SUMMARY"
+        done
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| **TOTAL** | **${TOTAL_LINES_COVERED}/${TOTAL_LINES_COUNT}** | **${TOTAL_LINES}%** | | **${TOTAL_FUNCTIONS}%** | | **${TOTAL_REGIONS}%** |" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Generate HTML report
       shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/steps/setup-rust
         with:
           targets: ${{ matrix.config.target }}
-          cache-key: build-${{ matrix.config.target }}
+          cache-key: stable
           install-musl-tools: ${{ contains(matrix.config.target, 'musl') }}
 
       - name: Build (simple)

--- a/.github/workflows/reusable-miri.yml
+++ b/.github/workflows/reusable-miri.yml
@@ -3,11 +3,6 @@ name: Reusable Miri
 on:
   workflow_call:
     inputs:
-      skip-patterns:
-        description: 'Test name patterns to skip (Miri cannot run I/O-heavy tests)'
-        required: false
-        default: '--skip service --skip coordinator'
-        type: string
       continue-on-error:
         description: 'Whether to allow this check to fail without failing the workflow'
         required: false
@@ -29,7 +24,7 @@ jobs:
           cache-key: nightly
 
       - name: Run Miri
-        run: cargo +nightly miri test --workspace -- ${{ inputs.skip-patterns }}
+        run: cargo +nightly miri test --workspace --all-features
         continue-on-error: ${{ inputs.continue-on-error }}
         env:
           MIRIFLAGS: -Zmiri-disable-isolation

--- a/libraries/tacacsrs_agent/src/service/coordinator.rs
+++ b/libraries/tacacsrs_agent/src/service/coordinator.rs
@@ -495,6 +495,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // real Unix socket + gRPC I/O
     async fn test_unix_socket_failover_and_preferred_recovery() {
         let primary = Arc::new(FakeConnection {
             address: "primary:49".to_owned(),
@@ -555,6 +556,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // real Unix socket + filesystem I/O
     async fn test_existing_socket_path_is_not_unlinked() {
         let primary = Arc::new(FakeConnection {
             address: "primary:49".to_owned(),
@@ -586,6 +588,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // real Unix socket + filesystem I/O
     async fn test_stale_socket_path_is_replaced() {
         let primary = Arc::new(FakeConnection {
             address: "primary:49".to_owned(),

--- a/libraries/tacacsrs_agent/src/service/state.rs
+++ b/libraries/tacacsrs_agent/src/service/state.rs
@@ -700,6 +700,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_server_selection_wraps_to_later_server() {
         let first = Arc::new(FakeConnection {
             address: "server-a:49".to_owned(),
@@ -738,6 +739,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_warm_connections_stops_after_first_responsive_server() {
         let first = Arc::new(FakeConnection {
             address: "server-a:49".to_owned(),
@@ -783,6 +785,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_concurrent_failover_coalesces_connection_attempts() {
         let first = Arc::new(FakeConnection {
             address: "server-a:49".to_owned(),
@@ -828,6 +831,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_non_single_connection_is_reconnected_for_next_request() {
         let connector = Arc::new(SingleSessionConnector {
             address: "server-a:49".to_owned(),
@@ -857,6 +861,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_drain_returns_immediately_with_no_active_clients() {
         let release = Arc::new(Notify::new());
         let connector = Arc::new(BlockingConnector {
@@ -876,6 +881,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_drain_waits_for_in_flight_request_then_completes() {
         let release = Arc::new(Notify::new());
         let connector = Arc::new(BlockingConnector {
@@ -923,6 +929,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_drain_completes_when_guard_drops_between_check_and_await() {
         // Regression test for the lost-wakeup race: the guard drops (and
         // notifies) in the window between the load-check and the notified().await
@@ -972,6 +979,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_default_dedicated_connections_handle_concurrent_requests() {
         let connector = Arc::new(ExclusiveSessionConnector {
             address: "server:49".to_owned(),
@@ -1007,6 +1015,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio spawn/time not supported
     async fn test_dedicated_exchange_upgrades_to_shared_connection() {
         let connection = Arc::new(FakeConnection {
             address: "server:49".to_owned(),

--- a/libraries/tacacsrs_networking/src/transport/tls/config_builder.rs
+++ b/libraries/tacacsrs_networking/src/transport/tls/config_builder.rs
@@ -129,6 +129,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // aws-lc-rs FFI in ClientConfig crypto provider
     fn with_client_auth_der_accepts_valid_der() {
         let (cert_chain, key_der) = sample_client_auth_der();
 
@@ -140,12 +141,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // aws-lc-rs FFI in ClientConfig crypto provider
     fn build_without_client_auth_succeeds() {
         let config = TlsConfigurationBuilder::new().build();
         assert!(config.is_ok(), "unexpected error: {config:?}");
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // aws-lc-rs FFI in ClientConfig crypto provider
     fn build_with_disabled_verification_succeeds() {
         let config = TlsConfigurationBuilder::new()
             .with_certificate_verification_disabled(true)


### PR DESCRIPTION
This pull request introduces improvements to CI coverage reporting and Miri testing, and enhances test reliability under Miri by selectively skipping incompatible tests. The changes focus on clearer code coverage summaries, more robust caching in CI, and better support for running tests with the Miri interpreter.

**CI and Coverage Reporting Improvements:**

- Enhanced the code coverage summary in `.github/steps/generate-coverage/action.yml` to generate a markdown table with per-file and total coverage percentages for lines, functions, and regions, making the report more readable and actionable.
- Updated the Rust toolchain cache key in `.github/workflows/reusable-build.yml` to use a stable key, which should improve cache hit rates and build consistency.

**Miri Testing Enhancements:**

- Removed the `skip-patterns` input from `.github/workflows/reusable-miri.yml` and now run all tests with `--all-features`, simplifying the workflow and ensuring broader test coverage under Miri. [[1]](diffhunk://#diff-697d23bbb205f2e6aae25dd5e401be733937819a2adfec689724c4d5b7686e53L6-L10) [[2]](diffhunk://#diff-697d23bbb205f2e6aae25dd5e401be733937819a2adfec689724c4d5b7686e53L32-R27)

**Test Reliability under Miri:**

- Added `#[cfg_attr(miri, ignore)]` to tests in `libraries/tacacsrs_agent/src/service/coordinator.rs`, `libraries/tacacsrs_agent/src/service/state.rs`, and `libraries/tacacsrs_networking/src/transport/tls/config_builder.rs` that rely on features not supported by Miri (such as real I/O, tokio spawn/time, or FFI), ensuring that Miri runs only compatible tests and reducing spurious failures. [[1]](diffhunk://#diff-e264a03a52b1c45ac4de1c1abcac763f8daee0090751c3260bf780b334bfde5eR498) [[2]](diffhunk://#diff-e264a03a52b1c45ac4de1c1abcac763f8daee0090751c3260bf780b334bfde5eR559) [[3]](diffhunk://#diff-e264a03a52b1c45ac4de1c1abcac763f8daee0090751c3260bf780b334bfde5eR591) [[4]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R703) [[5]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R742) [[6]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R788) [[7]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R834) [[8]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R864) [[9]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R884) [[10]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R932) [[11]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R982) [[12]](diffhunk://#diff-600b2cf8d2b41f17ab79c93e06a1a66fecb300d9158c56132b086182302911e7R1018) [[13]](diffhunk://#diff-96c614caae2eee4e2985e93c2b652ad7689d6843d4d86c9667079f154cf9e255R132) [[14]](diffhunk://#diff-96c614caae2eee4e2985e93c2b652ad7689d6843d4d86c9667079f154cf9e255R144-R151)

These changes collectively make the CI outputs more informative, improve the efficiency of builds, and ensure that Miri-based testing is both broader and more reliable.