### PR TITLE
Enhance security with seccomp policy and exec path verification

### DIFF
--- a/.github/instructions/session-wrapper-wsl-testing.instructions.md
+++ b/.github/instructions/session-wrapper-wsl-testing.instructions.md
@@ -1,0 +1,16 @@
+---
+description: "Use when testing on Windows while changing the session-wrapper project. Prefer WSL for Linux-specific validation and map Windows paths to /mnt/<drive>/<path>."
+applyTo: "executables/session_wrapper/**,docs/session-wrapper-testing.md"
+---
+# Session Wrapper WSL Testing
+
+- When making or validating changes to `session-wrapper` from Windows, prefer WSL for tests that exercise Linux-only behavior such as seccomp, process supervision, signals, shell scripts, or demo execution.
+- The repository is typically available in WSL under `/mnt/<drive>/<path>`. For example, `x:/code/tacacs-rs` maps to `/mnt/x/code/tacacs-rs`.
+- Use the current workspace path to derive the WSL path. For this repo, `x:/tacacs-rs-2` maps to `/mnt/x/tacacs-rs-2`.
+- From PowerShell, run WSL commands with an explicit working directory, for example:
+
+```powershell
+wsl --cd /mnt/x/tacacs-rs-2 -- bash -lc 'source "$HOME/.cargo/env" 2>/dev/null || true; cargo test -p session-wrapper'
+```
+
+- For shell demos, run them in WSL with bounded timeouts so a process-supervision regression cannot leave the validation stuck indefinitely.

--- a/docs/session-wrapper-testing.md
+++ b/docs/session-wrapper-testing.md
@@ -8,7 +8,7 @@ For architecture, CLI shape, and current implementation scope, see the [session-
 
 The session wrapper currently verifies process lifecycle and seccomp user notification wiring. TACACS+ authorization decisioning is intentionally stubbed as allow-all for now, so these smoke tests do not require a running `tacacsrs-agentd` service or TACACS+ server.
 
-The trailing `COMMAND [ARGS]...` is still required because it is the authorization context. The process that is executed today is `--shell`, so smoke tests use small temporary scripts as the shell.
+The trailing `COMMAND [ARGS]...` is the process that is executed under supervision. Smoke tests use small temporary scripts as the wrapped command.
 
 ## Demo scripts
 
@@ -17,7 +17,7 @@ Runnable allow-all demos live in `executables/session_wrapper/demo/`:
 | Script | Purpose |
 |--------|---------|
 | `allow-all-basic.sh` | Builds `session-wrapper`, runs a short wrapped script, and verifies the wrapped process wrote a marker file |
-| `allow-all-descendants.sh` | Runs a wrapped script that exits while a descendant continues, with `--intercept-fork` enabled |
+| `allow-all-descendants.sh` | Runs a wrapped script that exits while a descendant continues |
 | `allow-all-interactive-bash.sh` | Starts an interactive Bash session under the current allow-all supervisor for manual exploration |
 
 Run them from anywhere inside a Linux x86_64 checkout:
@@ -85,10 +85,10 @@ chmod +x "$tmp/exit-zero"
 
 SESSION_WRAPPER_SMOKE_MARKER="$tmp/marker" \
 timeout 10s target/debug/session-wrapper \
-  --shell "$tmp/exit-zero" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
+  --fail-policy open \
   -- "$tmp/exit-zero"
 
 test "$(cat "$tmp/marker")" = "ok"
@@ -107,12 +107,12 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
 if timeout 10s target/debug/session-wrapper \
-  --shell "$tmp/does-not-exist" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
+  --fail-policy open \
   -- "$tmp/does-not-exist" 2>"$tmp/error"; then
-  echo "expected session-wrapper to fail for a missing shell" >&2
+  echo "expected session-wrapper to fail for a missing command" >&2
   exit 1
 fi
 
@@ -143,11 +143,10 @@ chmod +x "$tmp/descendant"
 
 SESSION_WRAPPER_DESCENDANT_MARKER="$tmp/descendant-marker" \
 timeout 10s target/debug/session-wrapper \
-  --intercept-fork \
-  --shell "$tmp/descendant" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
+  --fail-policy open \
   -- "$tmp/descendant"
 
 test "$(cat "$tmp/descendant-marker")" = "descendant-ok"
@@ -177,10 +176,10 @@ target_gid=$(id -g)
 
 sudo env SESSION_WRAPPER_IDENTITY_MARKER="$tmp/identity-marker" \
   target/debug/session-wrapper \
-  --shell "$tmp/identity" \
   --user "$target_user" \
   --user-uid "$target_uid" \
   --user-gid "$target_gid" \
+  --fail-policy open \
   -- "$tmp/identity"
 
 test "$(cat "$tmp/identity-marker")" = "$target_uid:$target_gid"

--- a/executables/session_wrapper/README.md
+++ b/executables/session_wrapper/README.md
@@ -1,6 +1,6 @@
 # session-wrapper
 
-`session-wrapper` is a Linux `x86_64` proof-of-concept login/session wrapper for TACACS+ command authorization. It starts a user shell under a seccomp user-notification filter so the parent wrapper process can observe every `execve` crossing and decide — in real time — whether to allow or deny command execution.
+`session-wrapper` is a Linux `x86_64` proof-of-concept login/session wrapper for TACACS+ command authorization. It starts a command under a seccomp user-notification filter so the parent wrapper process can observe every `execve` crossing and decide — in real time — whether to allow or deny command execution.
 
 ## Platform support
 
@@ -13,11 +13,11 @@ The wrapper:
 1. Parses login/session context from CLI arguments.
 2. Optionally loads an exec allowlist (one path per line; built-in defaults always active).
 3. Forks a child process.
-4. Installs a seccomp user-notification filter in the child (notify on `execve`/`execveat`; optionally `clone`/`fork`).
+4. Installs a seccomp user-notification filter in the child (notify on `execve`/`execveat`).
 5. Sends the seccomp notification listener fd from child to parent over a Unix socketpair.
 6. Connects to the TACACS+ IPC agent and starts the supervisor in the parent.
 7. Releases the child once the supervisor is ready.
-8. Drops the child to the requested UID/GID and execs the configured `--shell`.
+8. Drops the child to the requested UID/GID and execs `COMMAND [ARGS]...`.
 9. For each intercepted exec:
    - Checks the exec path against the **allowlist** — if matched, responds CONTINUE immediately.
    - Otherwise, sends a TACACS+ **accounting** record to the agent and interprets the response status as allow/deny.
@@ -68,7 +68,6 @@ The policy is intentionally narrow — not a general sandbox:
 | Syscall family | Action | Purpose |
 |----------------|--------|---------|
 | `execve`, `execveat` | Notify parent | Command execution authorization boundary |
-| `clone`, `fork`, `vfork`, `clone3` | Optional notify (`--intercept-fork`) | Descendant visibility |
 | `ptrace` | `EPERM` | Prevent ptrace tampering |
 | Everything else | Allow | Keep normal shell behavior working |
 
@@ -80,7 +79,6 @@ Minimal local smoke-test invocation:
 cargo build -p session-wrapper
 
 target/debug/session-wrapper \
-  --shell /bin/bash \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
@@ -91,16 +89,14 @@ Useful options:
 
 | Option | Meaning |
 |--------|---------|
-| `--shell <PATH>` | Program execed in the child after privilege drop |
 | `--user <NAME>` | Target username for TACACS+ accounting context |
 | `--user-uid <UID>` | Target UID |
 | `--user-gid <GID>` | Target primary GID |
 | `--service-endpoint <PATH_OR_ADDR>` | TACACS+ IPC endpoint (default `/run/tacacs.sock`) |
 | `--fail-policy <closed\|open>` | What to do when the IPC agent is unreachable |
 | `--allowlist <FILE>` | Additional exec allowlist file |
-| `--intercept-fork` | Also notify fork-like syscalls |
 | `--port`, `--rem-addr` | TACACS+ context fields, typically from SSH environment |
-| `COMMAND [ARGS]...` | Authorization context sent in the accounting record |
+| `COMMAND [ARGS]...` | Program and arguments execed in the child after privilege drop |
 
 ## Demo scripts
 

--- a/executables/session_wrapper/demo/allow-all-basic.sh
+++ b/executables/session_wrapper/demo/allow-all-basic.sh
@@ -15,7 +15,7 @@ cargo build -p session-wrapper
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-cat >"$tmp/allow-all-basic-shell" <<'EOF'
+cat >"$tmp/allow-all-basic-command" <<'EOF'
 #!/bin/sh
 set -eu
 
@@ -23,16 +23,16 @@ echo "[wrapped] running as user=$(id -un) uid=$(id -u) gid=$(id -g)"
 echo "[wrapped] every execve is being continued by the current allow-all supervisor"
 printf 'allow-all-basic-ok\n' > "$SESSION_WRAPPER_DEMO_MARKER"
 EOF
-chmod +x "$tmp/allow-all-basic-shell"
+chmod +x "$tmp/allow-all-basic-command"
 
-echo "[demo] starting wrapped non-interactive shell"
+echo "[demo] starting wrapped non-interactive command"
 SESSION_WRAPPER_DEMO_MARKER="$tmp/marker" \
 timeout 10s target/debug/session-wrapper \
-  --shell "$tmp/allow-all-basic-shell" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
-  -- "$tmp/allow-all-basic-shell" "demo-command-context"
+  --fail-policy open \
+  -- "$tmp/allow-all-basic-command" "demo-command-context"
 
 if [[ "$(cat "$tmp/marker")" != "allow-all-basic-ok" ]]; then
   echo "[demo] marker was not written by the wrapped process" >&2

--- a/executables/session_wrapper/demo/allow-all-descendants.sh
+++ b/executables/session_wrapper/demo/allow-all-descendants.sh
@@ -15,7 +15,7 @@ cargo build -p session-wrapper
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-cat >"$tmp/allow-all-descendant-shell" <<'EOF'
+cat >"$tmp/allow-all-descendant-command" <<'EOF'
 #!/bin/sh
 set -eu
 
@@ -28,17 +28,16 @@ echo "[wrapped] initial shell pid=$$"
 echo "[wrapped] exiting initial shell while descendant continues"
 exit 0
 EOF
-chmod +x "$tmp/allow-all-descendant-shell"
+chmod +x "$tmp/allow-all-descendant-command"
 
-echo "[demo] starting wrapped shell with fork interception enabled"
+echo "[demo] starting wrapped command with descendant supervision"
 SESSION_WRAPPER_DESCENDANT_MARKER="$tmp/descendant-marker" \
 timeout 10s target/debug/session-wrapper \
-  --intercept-fork \
-  --shell "$tmp/allow-all-descendant-shell" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
-  -- "$tmp/allow-all-descendant-shell" "demo-command-context"
+  --fail-policy open \
+  -- "$tmp/allow-all-descendant-command" "demo-command-context"
 
 if [[ "$(cat "$tmp/descendant-marker")" != "allow-all-descendant-ok" ]]; then
   echo "[demo] descendant marker was not written" >&2

--- a/executables/session_wrapper/demo/allow-all-interactive-bash.sh
+++ b/executables/session_wrapper/demo/allow-all-interactive-bash.sh
@@ -31,9 +31,8 @@ cat <<EOF
 EOF
 
 exec target/debug/session-wrapper \
-  --intercept-fork \
-  --shell "$shell_path" \
   --user "$(id -un)" \
   --user-uid "$(id -u)" \
   --user-gid "$(id -g)" \
+  --fail-policy open \
   -- "$shell_path"

--- a/executables/session_wrapper/src/cli.rs
+++ b/executables/session_wrapper/src/cli.rs
@@ -1,10 +1,9 @@
 //! Command line contract for `session-wrapper`.
 //!
 //! The options model the eventual login-wrapper integration: caller-supplied
-//! user identity, TACACS+ context, fail policy, and a trailing command vector
-//! to authorize. In the current allow-all implementation the executed program
-//! is still `--shell`; the command vector is retained as the authorization
-//! context that future IPC code will send to the agent.
+//! user identity, TACACS+ context, fail policy, and the command vector to run
+//! under supervision.
+
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
@@ -24,10 +23,6 @@ pub enum FailPolicy {
 #[command(name = "session-wrapper", version, author)]
 #[command(about = "TACACS+ controlled login session wrapper", long_about = None)]
 pub struct Cli {
-    /// Shell to exec for the user.
-    #[arg(long, default_value = "/bin/bash")]
-    pub shell: PathBuf,
-
     /// Target username for the wrapped session.
     #[arg(long)]
     pub user: String,
@@ -59,10 +54,6 @@ pub struct Cli {
     /// Path to a file listing executables that are always allowed.
     #[arg(long, value_name = "FILE")]
     pub allowlist: Option<PathBuf>,
-
-    /// Intercept fork-like syscalls (fork/vfork/clone/clone3) with seccomp user notifications.
-    #[arg(long)]
-    pub intercept_fork: bool,
 
     /// TACACS+ port context field, typically populated from the SSH environment.
     #[arg(long)]
@@ -114,7 +105,6 @@ mod tests {
             "/bin/bash",
         ]);
 
-        assert_eq!(cli.shell, PathBuf::from("/bin/bash"));
         assert_eq!(cli.user, "alice");
         assert_eq!(cli.user_uid, 1000);
         assert_eq!(cli.user_gid, 1000);
@@ -123,7 +113,6 @@ mod tests {
         assert_eq!(cli.authorization_timeout_ms, 5_000);
         assert_eq!(cli.privilege_level, 1);
         assert_eq!(cli.verbose, 0);
-        assert!(!cli.intercept_fork);
         assert_eq!(cli.command, vec!["/bin/bash".to_owned()]);
     }
 
@@ -131,8 +120,6 @@ mod tests {
     fn optional_context_and_fail_policy_parse() {
         let cli = Cli::parse_from([
             "session-wrapper",
-            "--shell",
-            "/bin/zsh",
             "--user",
             "bob",
             "--user-uid",
@@ -149,7 +136,6 @@ mod tests {
             "15",
             "--allowlist",
             "/etc/session-wrapper.allow",
-            "--intercept-fork",
             "--port",
             "ssh",
             "--rem-addr",
@@ -160,13 +146,11 @@ mod tests {
             "version",
         ]);
 
-        assert_eq!(cli.shell, PathBuf::from("/bin/zsh"));
         assert_eq!(cli.service_endpoint, "127.0.0.1:9049");
         assert_eq!(cli.fail_policy, FailPolicy::Open);
         assert_eq!(cli.authorization_timeout_ms, 2_500);
         assert_eq!(cli.privilege_level, 15);
         assert_eq!(cli.allowlist, Some(PathBuf::from("/etc/session-wrapper.allow")));
-        assert!(cli.intercept_fork);
         assert_eq!(cli.port.as_deref(), Some("ssh"));
         assert_eq!(cli.rem_addr.as_deref(), Some("192.0.2.10"));
         assert_eq!(cli.verbose, 2);

--- a/executables/session_wrapper/src/linux.rs
+++ b/executables/session_wrapper/src/linux.rs
@@ -112,11 +112,10 @@ fn orchestrate_session(cli: &Cli, service_endpoint: &IpcEndpoint) -> anyhow::Res
 
     // Fork the session child.  No tokio runtime must be alive at this point.
     let session = process::spawn_session(process::ChildProcessConfig {
-        shell: cli.shell.clone(),
+        command: cli.command.clone(),
         user: cli.user.clone(),
         uid: cli.user_uid,
         gid: cli.user_gid,
-        intercept_fork: cli.intercept_fork,
     })
     .context("failed to spawn session process")?;
 

--- a/executables/session_wrapper/src/process.rs
+++ b/executables/session_wrapper/src/process.rs
@@ -8,7 +8,7 @@
 //!    `SCM_RIGHTS`, and then waits for a one-byte "supervisor ready" signal.
 //! 3. The parent owns the notification fd, starts the supervisor path, and only
 //!    then releases the child.
-//! 4. The child drops privileges and `execv`s the configured shell.
+//! 4. The child drops privileges and `execv`s the requested command.
 //!
 //! This is deliberately not implemented with `std::process::Command`: the
 //! parent must receive the seccomp listener before the child is allowed to run
@@ -22,8 +22,6 @@ use std::ffi::CString;
 use std::io;
 use std::mem::{self, MaybeUninit};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
 use std::ptr;
 
 use anyhow::{bail, Context, Result};
@@ -41,11 +39,10 @@ const MAX_CHILD_ERROR_LEN: u32 = 64 * 1024;
 /// need to borrow parent state after `fork()`.
 #[derive(Debug, Clone)]
 pub(crate) struct ChildProcessConfig {
-    pub(crate) shell: PathBuf,
+    pub(crate) command: Vec<String>,
     pub(crate) user: String,
     pub(crate) uid: libc::uid_t,
     pub(crate) gid: libc::gid_t,
-    pub(crate) intercept_fork: bool,
 }
 
 /// Owns the parent-side handles for a supervised child session.
@@ -136,9 +133,9 @@ impl SessionProcess {
 ///
 /// The returned session is not released yet. Callers must start whatever will
 /// answer seccomp notifications, then call `signal_supervisor_ready` before the
-/// child can drop privileges and exec the configured shell.
+/// child can drop privileges and exec the requested command.
 pub(crate) fn spawn_session(config: ChildProcessConfig) -> Result<SessionProcess> {
-    // Descendants that outlive the initial shell are reparented to this process
+    // Descendants that outlive the initial command are reparented to this process
     // instead of PID 1. That gives the supervisor a reliable way to keep the
     // notification fd alive until the whole wrapped process tree is gone.
     enable_child_subreaper().context("failed to mark session-wrapper as child subreaper")?;
@@ -206,17 +203,17 @@ fn run_child_or_exit(control_socket: OwnedFd, config: ChildProcessConfig) -> ! {
 /// Performs the child-side setup sequence before replacing the process image.
 ///
 /// Setup order is security-critical: install seccomp first, transfer the
-/// listener fd, wait for parent readiness, drop privileges, then exec the shell.
+/// listener fd, wait for parent readiness, drop privileges, then exec the command.
 fn run_child(control_socket: &OwnedFd, config: &ChildProcessConfig) -> Result<()> {
-    // Install the filter before dropping privileges or execing the shell so the
+    // Install the filter before dropping privileges or execing the command so the
     // entire user session, including the first exec, is mediated.
-    let notification_fd = seccomp::install_filter(config.intercept_fork)
+    let notification_fd = seccomp::install_filter()
         .context("failed to install session-wrapper seccomp filter in child")?;
     send_fd(control_socket.as_raw_fd(), notification_fd)
         .context("failed to send seccomp notification fd to parent")?;
     // After SCM_RIGHTS transfer the child must not keep its copy open. The
     // supervisor's lifetime should be controlled by the parent's OwnedFd, and
-    // no listener fd should leak into the user shell.
+    // no listener fd should leak into the user command.
     close_fd(notification_fd).context("failed to close child copy of seccomp notification fd")?;
 
     // The ready byte is the synchronization point that proves the parent has a
@@ -230,7 +227,7 @@ fn run_child(control_socket: &OwnedFd, config: &ChildProcessConfig) -> Result<()
         )
     })?;
 
-    exec_shell(&config.shell)
+    exec_command(&config.command)
 }
 
 /// Creates the bidirectional control socket used across fork.
@@ -582,7 +579,7 @@ fn drop_privileges(user: &str, gid: libc::gid_t, uid: libc::uid_t) -> Result<()>
     }
 
     let setuid_result = {
-        // SAFETY: setuid is called last so a failure prevents shell exec as root.
+        // SAFETY: setuid is called last so a failure prevents command exec as root.
         unsafe { libc::setuid(uid) }
     };
     if setuid_result == -1 {
@@ -606,26 +603,33 @@ fn current_effective_identity_matches(gid: libc::gid_t, uid: libc::uid_t) -> boo
     running_uid == uid && running_primary_gid == gid
 }
 
-/// Replaces the child process with the configured shell.
+/// Replaces the child process with the requested command.
 ///
 /// This uses `execv` directly because the child is already forked, filtered,
 /// and synchronized with the parent.
-fn exec_shell(shell: &Path) -> Result<()> {
-    let shell_cstr = path_to_cstring(shell).context("shell path is not a valid C string")?;
-    let argv = [shell_cstr.as_ptr(), ptr::null()];
+fn exec_command(command: &[String]) -> Result<()> {
+    let program = command
+        .first()
+        .context("command vector must contain at least one entry")?;
+    let cstrings: Vec<CString> = command
+        .iter()
+        .map(|arg| string_to_cstring(arg))
+        .collect::<Result<_>>()?;
+    let mut argv: Vec<*const libc::c_char> = cstrings.iter().map(|arg| arg.as_ptr()).collect();
+    argv.push(ptr::null());
 
     let result = {
-        // SAFETY: shell_cstr and argv are NUL-terminated and live until execv
+        // SAFETY: cstrings and argv are NUL-terminated and live until execv
         // either replaces this process image or returns an error.
-        unsafe { libc::execv(shell_cstr.as_ptr(), argv.as_ptr()) }
+        unsafe { libc::execv(cstrings[0].as_ptr(), argv.as_ptr()) }
     };
     debug_assert_eq!(result, -1);
-    bail!("execv({}) failed: {}", shell.display(), io::Error::last_os_error());
+    bail!("execv({program}) failed: {}", io::Error::last_os_error());
 }
 
-/// Converts a filesystem path to a C string suitable for `execv`.
-fn path_to_cstring(path: &Path) -> Result<CString> {
-    CString::new(path.as_os_str().as_bytes()).context("path contains an interior NUL byte")
+/// Converts a command argument to a C string suitable for `execv`.
+fn string_to_cstring(arg: &str) -> Result<CString> {
+    CString::new(arg).context("command argument contains an interior NUL byte")
 }
 
 /// Reads exactly `buffer.len()` bytes from a raw fd, retrying on interruption.
@@ -733,7 +737,7 @@ fn zeroed_msghdr() -> libc::msghdr {
 
 /// Marks the wrapper as a child subreaper for this process tree.
 ///
-/// This lets the wrapper reap descendants that outlive the initial shell,
+/// This lets the wrapper reap descendants that outlive the initial command,
 /// instead of losing visibility when they would otherwise be reparented to PID 1.
 fn enable_child_subreaper() -> Result<()> {
     let result = {
@@ -819,12 +823,11 @@ pub(crate) fn reap_available_children() -> Result<ReapStatus> {
 #[cfg(test)]
 mod tests {
     use super::{
-        describe_wait_status, path_to_cstring, read_child_setup_status_fd,
+        describe_wait_status, string_to_cstring, read_child_setup_status_fd,
         recv_initial_child_message, send_child_error, send_fd, socket_pair, ChildSetupStatus,
     };
     use std::io::Error;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-    use std::path::PathBuf;
 
     use anyhow::{bail, Result};
 
@@ -846,10 +849,10 @@ mod tests {
     }
 
     #[test]
-    fn path_to_cstring_rejects_nul_bytes() {
-        let path = PathBuf::from("bad\0path");
+    fn string_to_cstring_rejects_nul_bytes() {
+        let arg = "bad\0arg";
 
-        assert!(path_to_cstring(&path).is_err());
+        assert!(string_to_cstring(arg).is_err());
     }
 
     #[test]

--- a/executables/session_wrapper/src/process_reader.rs
+++ b/executables/session_wrapper/src/process_reader.rs
@@ -253,10 +253,9 @@ fn read_argv(
 ///
 /// # Return value
 ///
-/// Returns `Ok(Some((executable_path, argv)))` where `argv` is the full
+/// Returns `(executable_path, argv, filename_addr)` where `argv` is the full
 /// argument vector including `argv[0]` (which may differ from the executable
-/// path). Returns `Ok(None)` for non-exec syscalls (e.g. fork notifications
-/// when `--intercept-fork` is enabled).
+/// path).
 ///
 /// # TOCTOU mitigation
 ///
@@ -278,7 +277,7 @@ pub(crate) fn read_exec_args(
     notif_fd: ScmpFd,
     pid: u32,
     req: &ScmpNotifReq,
-) -> Result<Option<(String, Vec<String>, u64)>> {
+) -> Result<(String, Vec<String>, u64)> {
     // Resolve syscall names to their numeric IDs once.  `from_name` resolves
     // against the running kernel's syscall table, so this is always correct
     // for the current architecture.
@@ -296,9 +295,7 @@ pub(crate) fn read_exec_args(
         //                     args[1]               args[2]
         (req.data.args[1], req.data.args[2])
     } else {
-        // This is a fork-family or other non-exec syscall. There are no exec
-        // arguments to read; the caller should just continue the syscall.
-        return Ok(None);
+        bail!("unexpected non-exec syscall notification: {}", req.data.syscall);
     };
 
     // Bracket the filename read between two validity checks. If the target
@@ -316,7 +313,7 @@ pub(crate) fn read_exec_args(
 
     let argv = read_argv(notif_fd, req.id, pid, argv_addr)?;
 
-    Ok(Some((filename, argv, filename_addr)))
+    Ok((filename, argv, filename_addr))
 }
 
 /// Re-reads the exec path from process memory and verifies it has not changed.

--- a/executables/session_wrapper/src/process_reader.rs
+++ b/executables/session_wrapper/src/process_reader.rs
@@ -270,11 +270,15 @@ fn read_argv(
 ///
 /// I/O failures reading from `/proc/[pid]/mem`, oversized strings, and
 /// notification invalidity all produce errors.
+///
+/// On success, returns `(exec_path, argv, filename_addr)`. The caller can
+/// use `filename_addr` with [`verify_exec_path_unchanged`] to re-read the
+/// path just before sending `CONTINUE`, shrinking the TOCTOU window.
 pub(crate) fn read_exec_args(
     notif_fd: ScmpFd,
     pid: u32,
     req: &ScmpNotifReq,
-) -> Result<Option<(String, Vec<String>)>> {
+) -> Result<Option<(String, Vec<String>, u64)>> {
     // Resolve syscall names to their numeric IDs once.  `from_name` resolves
     // against the running kernel's syscall table, so this is always correct
     // for the current architecture.
@@ -312,7 +316,44 @@ pub(crate) fn read_exec_args(
 
     let argv = read_argv(notif_fd, req.id, pid, argv_addr)?;
 
-    Ok(Some((filename, argv)))
+    Ok(Some((filename, argv, filename_addr)))
+}
+
+/// Re-reads the exec path from process memory and verifies it has not changed.
+///
+/// This is the primary TOCTOU mitigation for `SECCOMP_USER_NOTIF_FLAG_CONTINUE`.
+/// The supervisor calls this **immediately before** sending the `CONTINUE`
+/// response, after the authorization decision has been made. If the path has
+/// changed between the original read (used for authorization) and this re-read,
+/// a racing thread in the child process has swapped the filename buffer and the
+/// exec must be denied.
+///
+/// This does not eliminate the TOCTOU window entirely — there is still a small
+/// gap between this re-read and the kernel's resume of the syscall — but it
+/// shrinks it from the full authorization round-trip (potentially milliseconds)
+/// to a single `pread` + `ioctl` (microseconds). Combined with the `userfaultfd`
+/// deny rule (which prevents deterministic control of the race), this makes
+/// exploitation extremely difficult in practice.
+///
+/// Returns `Ok(())` if the path is unchanged, or an error describing the
+/// mismatch.
+pub(crate) fn verify_exec_path_unchanged(
+    pid: u32,
+    filename_addr: u64,
+    expected_path: &str,
+) -> Result<()> {
+    let current_path = read_string_from_process(pid, filename_addr).with_context(|| {
+        format!("TOCTOU re-read: failed to read exec path from process {pid} at {filename_addr:#x}")
+    })?;
+
+    if current_path != expected_path {
+        bail!(
+            "TOCTOU detected: exec path changed between authorization and response \
+             (was {expected_path:?}, now {current_path:?}) in pid {pid}"
+        );
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/executables/session_wrapper/src/seccomp.rs
+++ b/executables/session_wrapper/src/seccomp.rs
@@ -47,6 +47,67 @@ fn syscall_rules(intercept_fork: bool) -> Vec<SyscallRule> {
             name: "ptrace",
             action: RuleAction::Errno(libc::EPERM),
         },
+        // Cross-process memory access (ptrace equivalents): deterministic
+        // TOCTOU exploitation via a cooperating process overwriting the
+        // frozen process's execve filename after the supervisor reads it.
+        SyscallRule {
+            name: "process_vm_writev",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "process_vm_readv",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        // pidfd_getfd can steal the seccomp notification fd from the
+        // supervisor, subverting the entire authorization model.
+        SyscallRule {
+            name: "pidfd_getfd",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        // userfaultfd makes the inherent seccomp unotify TOCTOU race
+        // deterministic by controlling page-fault resolution timing.
+        // Without it the race is probabilistic and hard to exploit.
+        SyscallRule {
+            name: "userfaultfd",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        // Namespace creation: user + mount namespaces allow bind-mounting
+        // a malicious binary over an allowlisted path, making path-based
+        // checks meaningless.
+        SyscallRule {
+            name: "unshare",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "setns",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        // Mount operations (legacy and new APIs): bind mounts can shadow
+        // any path in the filesystem.
+        SyscallRule {
+            name: "mount",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "umount2",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "mount_setattr",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "fsopen",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "fsmount",
+            action: RuleAction::Errno(libc::EPERM),
+        },
+        SyscallRule {
+            name: "move_mount",
+            action: RuleAction::Errno(libc::EPERM),
+        },
         SyscallRule {
             name: "execve",
             action: RuleAction::Notify,
@@ -170,27 +231,44 @@ pub(crate) fn install_filter(intercept_fork: bool) -> Result<RawFd> {
 mod tests {
     use std::io::{Read, Seek, SeekFrom, Write};
 
-    use super::{build_filter, syscall_rules, RuleAction, SyscallRule};
+    use super::{build_filter, syscall_rules, RuleAction};
 
     #[test]
     fn rules_match_expected_base_policy() {
+        let rules = syscall_rules(false);
+
+        // All deny rules must use Errno(EPERM).
+        let deny_names: Vec<&str> = rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Errno(libc::EPERM))
+            .map(|r| r.name)
+            .collect();
         assert_eq!(
-            syscall_rules(false),
+            deny_names,
             vec![
-                SyscallRule {
-                    name: "ptrace",
-                    action: RuleAction::Errno(libc::EPERM),
-                },
-                SyscallRule {
-                    name: "execve",
-                    action: RuleAction::Notify,
-                },
-                SyscallRule {
-                    name: "execveat",
-                    action: RuleAction::Notify,
-                },
+                "ptrace",
+                "process_vm_writev",
+                "process_vm_readv",
+                "pidfd_getfd",
+                "userfaultfd",
+                "unshare",
+                "setns",
+                "mount",
+                "umount2",
+                "mount_setattr",
+                "fsopen",
+                "fsmount",
+                "move_mount",
             ]
         );
+
+        // Exec-family rules must use Notify.
+        let notify_names: Vec<&str> = rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Notify)
+            .map(|r| r.name)
+            .collect();
+        assert_eq!(notify_names, vec!["execve", "execveat"]);
     }
 
     #[test]

--- a/executables/session_wrapper/src/seccomp.rs
+++ b/executables/session_wrapper/src/seccomp.rs
@@ -1,9 +1,9 @@
 //! Seccomp policy construction for the session wrapper.
 //!
 //! The filter is intentionally narrow: default allow, notify on exec-family
-//! syscalls, optionally notify on fork-family syscalls, and deny ptrace. That
-//! gives the parent wrapper the decision points needed for command
-//! authorization without attempting to sandbox the entire session.
+//! syscalls, and deny known syscall families that can undermine command
+//! authorization. That gives the parent wrapper the decision points needed for
+//! command authorization without attempting to sandbox the entire session.
 //!
 //! `libseccomp-rs` owns the low-level BPF generation. This module only defines
 //! the policy in syscall terms and returns the user-notification listener fd to
@@ -36,13 +36,14 @@ struct SyscallRule {
     action: RuleAction,
 }
 
-/// Builds the list of syscall rules for the requested supervision mode.
+/// Builds the list of syscall rules for the wrapper policy.
 ///
 /// Exec-family notifications are always installed because they are the command
-/// authorization boundary. Fork-family notifications are optional and primarily
-/// support descendant lifecycle visibility and future richer policy.
-fn syscall_rules(intercept_fork: bool) -> Vec<SyscallRule> {
-    let mut rules = vec![
+/// authorization boundary. Fork-like syscalls are not notified because they do
+/// not carry command material; descendants inherit this filter and are mediated
+/// when they later call `execve` or `execveat`.
+fn syscall_rules() -> Vec<SyscallRule> {
+    vec![
         SyscallRule {
             name: "ptrace",
             action: RuleAction::Errno(libc::EPERM),
@@ -116,41 +117,14 @@ fn syscall_rules(intercept_fork: bool) -> Vec<SyscallRule> {
             name: "execveat",
             action: RuleAction::Notify,
         },
-    ];
-
-    if intercept_fork {
-        // Fork interception is optional because exec notifications alone are
-        // enough for command authorization. Enabling fork-family notifications
-        // gives the supervisor earlier visibility into process tree expansion,
-        // which is useful for lifecycle tests and future richer policy.
-        rules.extend([
-            SyscallRule {
-                name: "clone",
-                action: RuleAction::Notify,
-            },
-            SyscallRule {
-                name: "fork",
-                action: RuleAction::Notify,
-            },
-            SyscallRule {
-                name: "vfork",
-                action: RuleAction::Notify,
-            },
-            SyscallRule {
-                name: "clone3",
-                action: RuleAction::Notify,
-            },
-        ]);
-    }
-
-    rules
+    ]
 }
 
 /// Builds, but does not load, the `libseccomp-rs` filter context.
 ///
 /// Tests use this to inspect/export the generated policy without installing a
 /// filter into the test process.
-fn build_filter(intercept_fork: bool) -> Result<ScmpFilterContext> {
+fn build_filter() -> Result<ScmpFilterContext> {
     let mut filter = ScmpFilterContext::new(ScmpAction::Allow)
         .context("failed to create libseccomp filter context")?;
 
@@ -158,7 +132,7 @@ fn build_filter(intercept_fork: bool) -> Result<ScmpFilterContext> {
         .set_ctl_nnp(true)
         .context("failed to enable no_new_privs on seccomp filter")?;
 
-    for rule in syscall_rules(intercept_fork) {
+    for rule in syscall_rules() {
         let syscall = ScmpSyscall::from_name(rule.name)
             .with_context(|| format!("failed to resolve syscall '{}'", rule.name))?;
         let action = match rule.action {
@@ -192,7 +166,7 @@ fn ensure_user_notify_supported() -> Result<()> {
 ///
 /// The caller must transfer ownership of this fd to the parent supervisor before
 /// allowing the child to execute any syscall that can be notified.
-pub(crate) fn install_filter(intercept_fork: bool) -> Result<RawFd> {
+pub(crate) fn install_filter() -> Result<RawFd> {
     // A process can only have one useful listener for this filter. Reinstalling
     // would make ownership and notification routing ambiguous, so fail fast.
     if FILTER_INSTALLED
@@ -205,7 +179,7 @@ pub(crate) fn install_filter(intercept_fork: bool) -> Result<RawFd> {
     ensure_user_notify_supported()?;
 
     let result = (|| {
-        let filter = build_filter(intercept_fork)?;
+        let filter = build_filter()?;
         filter
             .load()
             .context("failed to install seccomp filter with libseccomp")?;
@@ -235,7 +209,7 @@ mod tests {
 
     #[test]
     fn rules_match_expected_base_policy() {
-        let rules = syscall_rules(false);
+        let rules = syscall_rules();
 
         // All deny rules must use Errno(EPERM).
         let deny_names: Vec<&str> = rules
@@ -272,46 +246,22 @@ mod tests {
     }
 
     #[test]
-    fn rules_include_fork_family_when_requested() {
-        let rules = syscall_rules(true);
-        assert!(rules.iter().any(|rule| rule.name == "clone"));
-        assert!(rules.iter().any(|rule| rule.name == "fork"));
-        assert!(rules.iter().any(|rule| rule.name == "vfork"));
-        assert!(rules.iter().any(|rule| rule.name == "clone3"));
-    }
+    fn generated_bpf_program_is_not_empty() {
+        let filter = build_filter().expect("filter should build");
 
-    #[test]
-    fn generated_bpf_program_changes_when_fork_interception_is_enabled() {
-        let baseline_filter = build_filter(false).expect("baseline filter should build");
-        let with_fork_filter = build_filter(true).expect("fork-intercept filter should build");
-
-        let mut baseline_file = tempfile::tempfile().expect("tempfile should be created");
-        baseline_filter
-            .export_bpf(&baseline_file)
-            .expect("baseline filter should export BPF");
-        baseline_file.flush().expect("flush should succeed");
-        baseline_file
+        let mut filter_file = tempfile::tempfile().expect("tempfile should be created");
+        filter
+            .export_bpf(&filter_file)
+            .expect("filter should export BPF");
+        filter_file.flush().expect("flush should succeed");
+        filter_file
             .seek(SeekFrom::Start(0))
             .expect("seek should succeed");
-        let mut baseline = Vec::new();
-        baseline_file
-            .read_to_end(&mut baseline)
+        let mut bpf = Vec::new();
+        filter_file
+            .read_to_end(&mut bpf)
             .expect("read should succeed");
 
-        let mut with_fork_file = tempfile::tempfile().expect("tempfile should be created");
-        with_fork_filter
-            .export_bpf(&with_fork_file)
-            .expect("fork-intercept filter should export BPF");
-        with_fork_file.flush().expect("flush should succeed");
-        with_fork_file
-            .seek(SeekFrom::Start(0))
-            .expect("seek should succeed");
-        let mut with_fork = Vec::new();
-        with_fork_file
-            .read_to_end(&mut with_fork)
-            .expect("read should succeed");
-
-        assert!(!baseline.is_empty());
-        assert!(with_fork.len() > baseline.len());
+        assert!(!bpf.is_empty());
     }
 }

--- a/executables/session_wrapper/src/supervisor.rs
+++ b/executables/session_wrapper/src/supervisor.rs
@@ -422,16 +422,7 @@ async fn handle_one_notification(
     // completes in microseconds — fast enough to run synchronously in an async
     // task without spawn_blocking.
     let exec_info = match read_exec_args(notif_fd, pid, &req) {
-        Ok(Some(info)) => info,
-        Ok(None) => {
-            // Non-exec syscall (fork/clone/etc.) — always continue.
-            log::trace!("non-exec syscall from pid {pid}: allowing");
-            let resp = ScmpNotifResp::new_continue(req.id, ScmpNotifRespFlags::empty());
-            if let Err(err) = send_response(notif_fd, resp) {
-                log_or_propagate_send_error(err, notif_fd, req.id)?;
-            }
-            return Ok(());
-        }
+        Ok(info) => info,
         Err(err) => {
             if check_notification_valid(notif_fd, req.id).is_err() {
                 log::debug!(
@@ -732,9 +723,13 @@ pub(crate) async fn run_supervisor(
 /// 4. **Control socket** — propagates a child setup failure as an error.
 ///
 /// The loop exits when:
-/// - The notification receiver thread exits (channel closed).
-/// - All spawned handler tasks have completed.
 /// - `waitpid` reports no remaining children (`ECHILD`).
+/// - All spawned handler tasks have completed.
+///
+/// The notification receiver can still be blocked on the listener fd at that
+/// point because the parent owns the fd until the supervisor returns. Once no
+/// children or subreaped descendants remain, no future exec notifications can
+/// arrive, so child reaping is the authoritative shutdown signal.
 ///
 /// Extracted from [`run_supervisor`] to keep function sizes within clippy
 /// limits while keeping the full control flow visible in one place.
@@ -807,16 +802,18 @@ async fn dispatch_loop(
             res = &mut ctrl_handle, if !ctrl_done => {
                 ctrl_done = true;
                 match res {
-                    Ok(Ok(())) => {} // ControlClosed: child exec'd the shell
+                    Ok(Ok(())) => {} // ControlClosed: child exec'd the command
                     Ok(Err(e)) => return Err(e),
                     Err(e) => bail!("control socket watcher task panicked: {e}"),
                 }
             }
         }
 
-        // Exit when: no more notifications will arrive, all in-flight handlers
-        // have finished, and all child processes have been reaped.
-        if !notifications_open && handler_tasks.is_empty() && !has_children {
+        // Exit when all child processes have been reaped and all in-flight
+        // notification handlers have finished. The receiver thread may still
+        // be blocked on the listener fd owned by `SessionProcess`; returning
+        // lets that owner close the fd.
+        if !has_children && handler_tasks.is_empty() {
             break;
         }
     }

--- a/executables/session_wrapper/src/supervisor.rs
+++ b/executables/session_wrapper/src/supervisor.rs
@@ -433,7 +433,7 @@ async fn handle_one_notification(
             }
             log::warn!("failed to read exec args from pid {pid}: {err:#}");
             let decision = fail_policy_decision(config.fail_policy, "<unreadable>");
-            return apply_decision(notif_fd, &req, pid, 0, "<unreadable>", &decision);
+            return apply_decision(notif_fd, &req, pid, None, "<unreadable>", &decision);
         }
     };
 
@@ -482,7 +482,22 @@ async fn handle_one_notification(
         };
 
     // Step 4: Respond to the kernel.
-    apply_decision(notif_fd, &req, pid, filename_addr, &exec_path, &decision)
+    apply_decision(notif_fd, &req, pid, Some(filename_addr), &exec_path, &decision)
+}
+
+fn verify_exec_path_if_available(
+    pid: u32,
+    filename_addr: Option<u64>,
+    exec_path: &str,
+) -> Result<()> {
+    if let Some(filename_addr) = filename_addr {
+        verify_exec_path_unchanged(pid, filename_addr, exec_path)
+    } else {
+        log::warn!(
+            "allowing exec of {exec_path:?} for pid {pid} without TOCTOU verification: filename address unknown"
+        );
+        Ok(())
+    }
 }
 
 /// Sends the allow or deny kernel response for a seccomp notification.
@@ -491,6 +506,8 @@ async fn handle_one_notification(
 /// from `/proc/[pid]/mem` immediately before sending `CONTINUE`. If the path
 /// has changed since the original read (indicating a racing thread swapped it),
 /// the exec is denied with `EPERM` instead.
+/// If the exec path could not be read in the first place and fail-open chose
+/// `Allow`, the filename address is unknown and verification is skipped.
 ///
 /// If sending fails because the notification has expired (the target process
 /// exited during our IPC call), the function logs the race and returns `Ok(())`.
@@ -499,7 +516,7 @@ fn apply_decision(
     notif_fd: ScmpFd,
     req: &ScmpNotifReq,
     pid: u32,
-    filename_addr: u64,
+    filename_addr: Option<u64>,
     exec_path: &str,
     decision: &AuthDecision,
 ) -> Result<()> {
@@ -509,7 +526,7 @@ fn apply_decision(
             // thread between the initial read and this response. This is the
             // critical mitigation — it shrinks the TOCTOU window from the full
             // IPC round-trip to just pread + ioctl.
-            if let Err(err) = verify_exec_path_unchanged(pid, filename_addr, exec_path) {
+            if let Err(err) = verify_exec_path_if_available(pid, filename_addr, exec_path) {
                 log::warn!("{err:#}");
                 eprintln!("session-wrapper: exec denied (TOCTOU): {exec_path}");
                 let resp =
@@ -891,5 +908,11 @@ mod tests {
             AuthDecision::Deny(reason) => assert!(reason.contains("cmd")),
             AuthDecision::Allow => panic!("mandatory PASS_REPL replacement arg was allowed"),
         }
+    }
+
+    #[test]
+    fn unknown_filename_address_skips_exec_path_verification() {
+        verify_exec_path_if_available(1234, None, "<unreadable>")
+            .expect("unknown filename address should not fail TOCTOU verification");
     }
 }

--- a/executables/session_wrapper/src/supervisor.rs
+++ b/executables/session_wrapper/src/supervisor.rs
@@ -105,7 +105,7 @@ use super::cli::FailPolicy;
 use super::process::{
     ChildSetupStatus, SessionProcess, read_child_setup_status_fd, reap_available_children,
 };
-use super::process_reader::read_exec_args;
+use super::process_reader::{read_exec_args, verify_exec_path_unchanged};
 
 /// How often the dispatch loop polls for reaped children in addition to SIGCHLD.
 ///
@@ -442,16 +442,29 @@ async fn handle_one_notification(
             }
             log::warn!("failed to read exec args from pid {pid}: {err:#}");
             let decision = fail_policy_decision(config.fail_policy, "<unreadable>");
-            return apply_decision(notif_fd, &req, "<unreadable>", &decision);
+            return apply_decision(notif_fd, &req, pid, 0, "<unreadable>", &decision);
         }
     };
 
-    let (exec_path, exec_args) = exec_info;
+    let (exec_path, exec_args, filename_addr) = exec_info;
     log::debug!("pid {pid} exec: {exec_path:?} args={exec_args:?}");
 
     // Step 2: Fast-path allowlist check (O(1) HashSet lookup).
     if allowlist.is_allowed(&exec_path) {
         log::debug!("allowlist hit for {exec_path:?}: allowing without IPC");
+
+        // TOCTOU re-read: verify the path hasn't been swapped by a racing
+        // thread between the initial read and this response.
+        if let Err(err) = verify_exec_path_unchanged(pid, filename_addr, &exec_path) {
+            log::warn!("{err:#}");
+            eprintln!("session-wrapper: exec denied (TOCTOU): {exec_path}");
+            let resp = ScmpNotifResp::new_error(req.id, -libc::EPERM, ScmpNotifRespFlags::empty());
+            if let Err(err) = send_response(notif_fd, resp) {
+                log_or_propagate_send_error(err, notif_fd, req.id)?;
+            }
+            return Ok(());
+        }
+
         let resp = ScmpNotifResp::new_continue(req.id, ScmpNotifRespFlags::empty());
         if let Err(err) = send_response(notif_fd, resp) {
             log_or_propagate_send_error(err, notif_fd, req.id)?;
@@ -478,10 +491,15 @@ async fn handle_one_notification(
         };
 
     // Step 4: Respond to the kernel.
-    apply_decision(notif_fd, &req, &exec_path, &decision)
+    apply_decision(notif_fd, &req, pid, filename_addr, &exec_path, &decision)
 }
 
 /// Sends the allow or deny kernel response for a seccomp notification.
+///
+/// When the decision is `Allow`, performs a TOCTOU re-read of the exec path
+/// from `/proc/[pid]/mem` immediately before sending `CONTINUE`. If the path
+/// has changed since the original read (indicating a racing thread swapped it),
+/// the exec is denied with `EPERM` instead.
 ///
 /// If sending fails because the notification has expired (the target process
 /// exited during our IPC call), the function logs the race and returns `Ok(())`.
@@ -489,11 +507,28 @@ async fn handle_one_notification(
 fn apply_decision(
     notif_fd: ScmpFd,
     req: &ScmpNotifReq,
+    pid: u32,
+    filename_addr: u64,
     exec_path: &str,
     decision: &AuthDecision,
 ) -> Result<()> {
     match decision {
         AuthDecision::Allow => {
+            // TOCTOU re-read: verify the path hasn't been swapped by a racing
+            // thread between the initial read and this response. This is the
+            // critical mitigation — it shrinks the TOCTOU window from the full
+            // IPC round-trip to just pread + ioctl.
+            if let Err(err) = verify_exec_path_unchanged(pid, filename_addr, exec_path) {
+                log::warn!("{err:#}");
+                eprintln!("session-wrapper: exec denied (TOCTOU): {exec_path}");
+                let resp =
+                    ScmpNotifResp::new_error(req.id, -libc::EPERM, ScmpNotifRespFlags::empty());
+                if let Err(err) = send_response(notif_fd, resp) {
+                    log_or_propagate_send_error(err, notif_fd, req.id)?;
+                }
+                return Ok(());
+            }
+
             log::debug!("allowing exec of {exec_path:?} for pid {}", req.pid);
             let resp = ScmpNotifResp::new_continue(req.id, ScmpNotifRespFlags::empty());
             // `SECCOMP_USER_NOTIF_FLAG_CONTINUE` tells the kernel to proceed with


### PR DESCRIPTION
This pull request updates the `session-wrapper` prototype to generalize its execution model from launching a user shell to launching an arbitrary command with arguments. It removes the `--shell` and `--intercept-fork` options, updates documentation and demo scripts to match the new behavior, and simplifies the codebase to reflect these changes.

**Command execution model changes:**

* The `--shell` option is removed; instead, the command to execute is now always taken from the trailing positional arguments (`COMMAND [ARGS]...`). All code and documentation references to "shell" are replaced with "command" for clarity. [[1]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL3-R3) [[2]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL16-R20) [[3]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL83) [[4]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL94-R99) [[5]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL11-R11) [[6]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL88-R91) [[7]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL110-R115) [[8]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL146-R149) [[9]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL180-R182) [[10]](diffhunk://#diff-57be73d1b1a1e1210768af9b775db9004585d747b3f64d3ec7440f6dafea0f8eL18-R35) [[11]](diffhunk://#diff-e516794c076ab39a621076efc943a28f3acb2d5aec084467e935c8e4842c5c52L18-R18) [[12]](diffhunk://#diff-e516794c076ab39a621076efc943a28f3acb2d5aec084467e935c8e4842c5c52L31-R40) [[13]](diffhunk://#diff-822f3b66b31daed3b6f209193bb1f9bbd03fe1bdec8cba32e36b92c6d54a946aL34-R37) [[14]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL4-R6) [[15]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL27-L30) [[16]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL117) [[17]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL126-L135) [[18]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL163-L169) [[19]](diffhunk://#diff-d629369d9451541d9c93f06ffc1c23766fcf237e4bc52a6188e5a392300be6afL115-L119) [[20]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL11-R11) [[21]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL44-L48) [[22]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL139-R138) [[23]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL209-R216)

* The `--intercept-fork` option is removed from both the CLI and implementation. Fork-like syscall interception is no longer configurable. [[1]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL16-R20) [[2]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL71) [[3]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL63-L66) [[4]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL117) [[5]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL126-L135) [[6]](diffhunk://#diff-87a281b128fc440b41dc72367b174557b86976912766e4fc115e5abfb6ef9bccL152) [[7]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL209-R216)

**Documentation and demo script updates:**

* All documentation, including the main `README.md` and `session-wrapper-testing.md`, is revised to describe the new command execution model and to remove references to the shell and the fork interception option. [[1]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL3-R3) [[2]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL16-R20) [[3]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL83) [[4]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL94-R99) [[5]](diffhunk://#diff-7cccde1a66531876de99f7f4e4b463be6ad67fbbdaa48b6f9dc621a2794d258bL71) [[6]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL11-R11) [[7]](diffhunk://#diff-dad6bf430749d34091ec4163ca874ee0fe122c87e5d7d052a56054bdd043f71eL20-R20)

* Demo scripts are updated to use the new command execution interface and to remove the `--shell` and `--intercept-fork` options. Temporary script variables and echo statements are renamed for consistency with the new model. [[1]](diffhunk://#diff-57be73d1b1a1e1210768af9b775db9004585d747b3f64d3ec7440f6dafea0f8eL18-R35) [[2]](diffhunk://#diff-e516794c076ab39a621076efc943a28f3acb2d5aec084467e935c8e4842c5c52L18-R18) [[3]](diffhunk://#diff-e516794c076ab39a621076efc943a28f3acb2d5aec084467e935c8e4842c5c52L31-R40) [[4]](diffhunk://#diff-822f3b66b31daed3b6f209193bb1f9bbd03fe1bdec8cba32e36b92c6d54a946aL34-R37)

**Codebase simplification:**

* The `ChildProcessConfig` struct and related process management code are simplified to only require a command vector, not a shell path or fork interception flag. [[1]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL44-L48) [[2]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL139-R138) [[3]](diffhunk://#diff-33f04d59bca356bba48539ba327f2f73f8e51f55720530a44a1534aab8ad3d0fL209-R216) [[4]](diffhunk://#diff-d629369d9451541d9c93f06ffc1c23766fcf237e4bc52a6188e5a392300be6afL115-L119)

These changes clarify the session-wrapper's intended usage and reduce complexity in both code and documentation.