### PR TITLE
Add TACACS+ Authorization Request and Reply Support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,7 +99,7 @@ session-wrapper -> tacacsrs-agent-client
 - `tacacsrs-flow-abstractions` contains sans-I/O flow helpers and traits such as
   packet construction/parsing and `ClientSessionFlowIoTrait`.
 - `tacacsrs-flows` contains high-level protocol flows such as
-  `AccountingFlowTrait`, implemented over session I/O abstractions.
+  `AccountingFlow`, implemented over session I/O abstractions.
 - `tacacsrs-networking` owns transports, packet reader/writer plumbing,
   `TacacsConnection`, `DedicatedConnection`, session multiplexing, single-connect
   tracking, and config-driven connection establishment.
@@ -196,7 +196,7 @@ injects them during builds through `.github/steps/compute-versions` and
 - Keep service-like structs concrete. Put generics on methods when practical,
   and use `Box<dyn Trait>` only at runtime-polymorphic boundaries.
 - Reuse existing abstractions: `Transport`, `BoxedTransport`,
-  `ClientSessionFlowIoTrait`, `AccountingFlowTrait`, `ConfigDatastore`,
+  `ClientSessionFlowIoTrait`, `AccountingFlow`, `ConfigDatastore`,
   `ServiceError`, `IpcEndpoint`, and the mock transport/controller patterns.
 - Essential behavior should be inherent on the owning type; traits should expose
   extension or abstraction seams, not hide core functionality.

--- a/.github/instructions/gh-issue-creation.instructions.md
+++ b/.github/instructions/gh-issue-creation.instructions.md
@@ -1,0 +1,40 @@
+---
+description: Use when creating or editing GitHub issues via the `gh` CLI in PowerShell terminals.
+applyTo: "**"
+---
+
+# Creating GitHub Issues with `gh` CLI (PowerShell)
+
+## Body file approach (preferred)
+
+PowerShell here-strings (`@"..."@`) interpret backtick sequences as escape
+characters (e.g. `` `u `` is a Unicode escape). Issue bodies almost always
+contain inline code with backticks, so **always use `--body-file`**:
+
+1. Write the issue body to a temporary Markdown file:
+   ```
+   .github/issue-body-tmp.md
+   ```
+2. Create or edit the issue:
+   ```powershell
+   gh issue create --title "Title here" --body-file .github/issue-body-tmp.md
+   gh issue edit 123 --body-file .github/issue-body-tmp.md
+   ```
+3. Delete the temporary file:
+   ```powershell
+   Remove-Item .github/issue-body-tmp.md
+   ```
+
+## When `--body "..."` is safe
+
+Only use inline `--body` for short bodies that contain **no backticks, no
+single quotes, and no dollar signs**. If in doubt, use `--body-file`.
+
+## Issue body conventions
+
+- Start with a summary section explaining the problem or change but without a markdown title.
+- Include a `## Plan` section with numbered steps that reference specific files
+  and describe the expected code changes. This makes the issue actionable by
+  Copilot or another agent later.
+- Use fenced code blocks with language identifiers for examples.
+- Reference file paths relative to the repository root.

--- a/docs/session-wrapper-testing.md
+++ b/docs/session-wrapper-testing.md
@@ -1,6 +1,6 @@
 # Session Wrapper Smoke and Integration Testing
 
-This document describes local checks that verify the Linux `session-wrapper` path is operating as expected. The wrapper is currently Linux x86_64 only; other platforms build the noop entrypoint.
+This document describes local checks that verify the Linux `session-wrapper` path is operating as expected. The real process mediation backend is Linux x86_64 only. Other platforms build the portable CLI, allowlist, deny-message, and authorization decision logic over a mock PAL backend that returns an explicit unsupported-platform error instead of executing or mediating commands.
 
 For architecture, CLI shape, and current implementation scope, see the [session-wrapper README](../executables/session_wrapper/README.md).
 
@@ -15,7 +15,7 @@ The trailing `COMMAND [ARGS]...` is the process that is executed under supervisi
 Runnable allow-all demos live in `executables/session_wrapper/demo/`:
 
 | Script | Purpose |
-|--------|---------|
+| ------ | ------- |
 | `allow-all-basic.sh` | Builds `session-wrapper`, runs a short wrapped script, and verifies the wrapped process wrote a marker file |
 | `allow-all-descendants.sh` | Runs a wrapped script that exits while a descendant continues |
 | `allow-all-interactive-bash.sh` | Starts an interactive Bash session under the current allow-all supervisor for manual exploration |
@@ -50,6 +50,17 @@ export PKG_CONFIG_PATH=/path/to/libseccomp-musl/lib/pkgconfig
 Native Alpine builds have one extra `libseccomp`/musl linking caveat. See the crate-local [Alpine Linux technical note](../executables/session_wrapper/README.alpine.md).
 
 ## Compile-time integration checks
+
+On non-Linux development machines, run the portable checks first:
+
+```bash
+cargo check -p session-wrapper
+cargo test -p session-wrapper
+cargo clippy -p session-wrapper --all-targets -- -D warnings
+```
+
+These checks exercise the portable modules and the mock PAL backend. They do not
+validate fork, seccomp, `/proc`, signal, or child-reaping behavior.
 
 Run these on Linux x86_64:
 
@@ -192,7 +203,7 @@ Expected result: the marker contains the target user's UID and primary GID, not 
 These smoke tests are good candidates for a Linux-only integration test job once the wrapper behavior stabilizes:
 
 | Check | Requires root | Purpose |
-|-------|---------------|---------|
+| ----- | ------------- | ------- |
 | Compile-time integration checks | No | Validate Rust code, seccomp policy construction, fd passing, and musl compatibility |
 | Child starts and exits | No | Validate notification fd handoff, ready synchronization, and child exec |
 | Missing shell failure | No | Validate child-to-parent setup error reporting |

--- a/docs/sonic-build-guide.md
+++ b/docs/sonic-build-guide.md
@@ -65,11 +65,15 @@ No runtime dependencies are required — the binaries are self-contained.
 
 ### Component roles on a SONiC switch
 
-| Binary             | Role on the switch                                            | Lifetime                       |
-|--------------------|---------------------------------------------------------------|--------------------------------|
-| `tacacsrs-agentd`  | Long-running daemon. Maintains TACACS+ connections to upstream servers and exposes `/run/tacacs.sock` for local IPC. | systemd service (always on)    |
-| `session-wrapper`  | **Not a daemon.** One process per SSH login, spawned by `sshd` via `ForceCommand` (or as the user's login shell). Forks the user's shell under a seccomp filter and proxies authorization through the agent. | Lives for the SSH session only |
-| `tacon`            | Operator CLI for ad-hoc TACACS+ requests. Useful for accounting test traffic and debugging the agent.                                          | One-shot CLI invocation        |
+- `tacacsrs-agentd`: Long-running daemon. Maintains TACACS+ connections to
+    upstream servers and exposes `/run/tacacs.sock` for local IPC. Lifetime:
+    systemd service, always on.
+- `session-wrapper`: **Not a daemon.** One process per SSH login, spawned by
+    `sshd` via `ForceCommand` or as the user's login shell. Forks the user's shell
+    under a seccomp filter and proxies authorization through the agent. Lifetime:
+    the SSH session.
+- `tacon`: Operator CLI for ad-hoc TACACS+ requests. Useful for accounting test
+    traffic and debugging the agent. Lifetime: one-shot CLI invocation.
 
 ### systemd interaction
 
@@ -131,8 +135,8 @@ file target/x86_64-unknown-linux-musl/release/session-wrapper
 # Should show: "statically linked"
 ```
 
-The CI build matrix in `.github/workflows/reusable-build.yml` uses
-`--workspace`, so `session-wrapper` is built and statically verified for the
-`x86_64-unknown-linux-musl` target on every PR alongside `tacon` and
+The CI target matrix in `.github/workflows/reusable-pipeline.yml` includes a
+MUSL official-build lane, so `session-wrapper` is built and statically verified
+for the `x86_64-unknown-linux-musl` target on every PR alongside `tacon` and
 `tacacsrs-agentd`. The supporting `setup-rust` step builds and caches a
 musl-targeted static `libseccomp` so the wrapper links cleanly.

--- a/executables/tacon/src/commands/accounting.rs
+++ b/executables/tacon/src/commands/accounting.rs
@@ -6,7 +6,7 @@ use tacacsrs_messages::enumerations::{
     TacacsAccountingFlags, TacacsAuthenticationMethod, TacacsAuthenticationService,
     TacacsAuthenticationType, TacacsFlags,
 };
-use tacacsrs_flows::accounting::AccountingFlowTrait;
+use tacacsrs_flows::accounting::AccountingFlow;
 use tacacsrs_networking::session::Session;
 
 /// Sends an accounting request to record command execution.

--- a/libraries/tacacsrs_agent/src/upstream.rs
+++ b/libraries/tacacsrs_agent/src/upstream.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 use tacacsrs_config::{TacacsPlusServer, TacacsPlusServerExt};
-use tacacsrs_flows::accounting::AccountingFlowTrait;
+use tacacsrs_flows::accounting::AccountingFlow;
 use tacacsrs_messages::accounting::request::AccountingRequest;
 use tacacsrs_messages::enumerations::{
     TacacsAccountingFlags, TacacsAccountingStatus, TacacsAuthenticationMethod,

--- a/libraries/tacacsrs_flow_abstractions/src/authorization.rs
+++ b/libraries/tacacsrs_flow_abstractions/src/authorization.rs
@@ -1,11 +1,11 @@
-use tacacsrs_messages::accounting::reply::AccountingReply;
-use tacacsrs_messages::accounting::request::AccountingRequest;
+use tacacsrs_messages::authorization::reply::AuthorizationReply;
+use tacacsrs_messages::authorization::request::AuthorizationRequest;
 use tacacsrs_messages::enumerations::{TacacsFlags, TacacsMajorVersion, TacacsMinorVersion, TacacsType};
 use tacacsrs_messages::header::Header;
 use tacacsrs_messages::packet::{Packet, PacketTrait};
 use tacacsrs_messages::traits::TacacsBodyTrait;
 
-/// Builds a TACACS+ accounting packet ready to send.
+/// Builds a TACACS+ authorization packet ready to send.
 ///
 /// The standard unencrypted flag is always set; callers can add protocol
 /// negotiation or custom flags through `custom_flags`.
@@ -14,22 +14,22 @@ use tacacsrs_messages::traits::TacacsBodyTrait;
 ///
 /// Returns an error if the serialized request is too large for a TACACS+
 /// header or if the packet cannot be constructed.
-pub fn build_accounting_packet(
+pub fn build_authorization_packet(
     session_id: u32,
     seq_no: u8,
-    request: &AccountingRequest,
+    request: &AuthorizationRequest,
     custom_flags: TacacsFlags,
 ) -> anyhow::Result<Packet> {
     let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
-        .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
+        .map_err(|_| anyhow::Error::msg("authorization request payload exceeds u32 length"))?;
     let flags = TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG | custom_flags;
 
     Packet::new(
         Header {
             major_version: TacacsMajorVersion::TacacsPlusMajor1,
             minor_version: TacacsMinorVersion::TacacsPlusMinorVerDefault,
-            tacacs_type: TacacsType::TacPlusAccounting,
+            tacacs_type: TacacsType::TacPlusAuthorisation,
             seq_no,
             flags,
             session_id,
@@ -39,11 +39,11 @@ pub fn build_accounting_packet(
     )
 }
 
-/// Parses an accounting reply from a response packet.
+/// Parses an authorization reply from a response packet.
 ///
 /// # Errors
 ///
-/// Returns an error if the packet body is not a valid TACACS+ accounting reply.
-pub fn parse_accounting_reply(response: &Packet) -> anyhow::Result<AccountingReply> {
-    AccountingReply::from_bytes(response.body())
+/// Returns an error if the packet body is not a valid TACACS+ authorization reply.
+pub fn parse_authorization_reply(response: &Packet) -> anyhow::Result<AuthorizationReply> {
+    AuthorizationReply::from_bytes(response.body())
 }

--- a/libraries/tacacsrs_flow_abstractions/src/lib.rs
+++ b/libraries/tacacsrs_flow_abstractions/src/lib.rs
@@ -1,4 +1,5 @@
 //! Shared abstraction traits between networking and flow implementations.
 
 pub mod accounting;
+pub mod authorization;
 pub mod client_session_flow_io;

--- a/libraries/tacacsrs_flows/src/authorization.rs
+++ b/libraries/tacacsrs_flows/src/authorization.rs
@@ -1,67 +1,67 @@
 use async_trait::async_trait;
 use log::info;
-use tacacsrs_flow_abstractions::accounting::{build_accounting_packet, parse_accounting_reply};
+use tacacsrs_flow_abstractions::authorization::{build_authorization_packet, parse_authorization_reply};
 use tacacsrs_flow_abstractions::client_session_flow_io::ClientSessionFlowIoTrait;
-use tacacsrs_messages::accounting::{reply::AccountingReply, request::AccountingRequest};
+use tacacsrs_messages::authorization::{reply::AuthorizationReply, request::AuthorizationRequest};
 use tacacsrs_messages::enumerations::TacacsFlags;
 use tacacsrs_messages::packet::PacketTrait;
 
-/// Fixed TACACS+ client accounting flow.
+/// Fixed TACACS+ client authorization flow.
 ///
 /// Implement this on any type that can provide [`ClientSessionFlowIoTrait`].
 #[async_trait]
-pub trait AccountingFlow: ClientSessionFlowIoTrait {
-    /// Sends an accounting request with default flags (`TAC_PLUS_UNENCRYPTED_FLAG`)
-    async fn send_accounting_request(
+pub trait AuthorizationFlow: ClientSessionFlowIoTrait {
+    /// Sends an authorization request with default flags (`TAC_PLUS_UNENCRYPTED_FLAG`).
+    async fn send_authorization_request(
         &self,
-        request: AccountingRequest,
-    ) -> anyhow::Result<AccountingReply> {
-        self.send_accounting_request_with_flags(request, TacacsFlags::empty())
+        request: AuthorizationRequest,
+    ) -> anyhow::Result<AuthorizationReply> {
+        self.send_authorization_request_with_flags(request, TacacsFlags::empty())
             .await
     }
 
-    /// Sends an accounting request with custom flags added to the header
+    /// Sends an authorization request with custom flags added to the header.
     ///
     /// # Arguments
     ///
-    /// * `request` - The accounting request to send
+    /// * `request` - The authorization request to send
     /// * `custom_flags` - Additional flags to set on the packet header
-    async fn send_accounting_request_with_flags(
+    async fn send_authorization_request_with_flags(
         &self,
-        request: AccountingRequest,
+        request: AuthorizationRequest,
         custom_flags: TacacsFlags,
-    ) -> anyhow::Result<AccountingReply> {
+    ) -> anyhow::Result<AuthorizationReply> {
         if self.is_complete().await {
             return Err(anyhow::Error::msg("Session is already complete"));
         }
 
         let sequence_number = self.next_sequence_number().await;
         let packet =
-            build_accounting_packet(self.session_id(), sequence_number, &request, custom_flags)?;
+            build_authorization_packet(self.session_id(), sequence_number, &request, custom_flags)?;
         let flags = packet.header().flags;
 
         info!(
-            target: "tacacsrs_flows::accounting",
-            "Sending Accounting Request with sequence number {} for session {} (flags: {:?})",
+            target: "tacacsrs_flows::authorization",
+            "Sending Authorization Request with sequence number {} for session {} (flags: {:?})",
             sequence_number, self.session_id(), flags
         );
 
         self.send_packet(packet).await?;
         let response = self.receive_packet().await?;
-        let reply = parse_accounting_reply(&response)?;
+        let reply = parse_authorization_reply(&response)?;
 
         self.complete().await;
 
         info!(
-            target: "tacacsrs_flows::accounting",
-            "Received Accounting Reply. Session now complete"
+            target: "tacacsrs_flows::authorization",
+            "Received Authorization Reply. Session now complete"
         );
 
         Ok(reply)
     }
 }
 
-impl<T> AccountingFlow for T where T: ClientSessionFlowIoTrait + ?Sized {}
+impl<T> AuthorizationFlow for T where T: ClientSessionFlowIoTrait + ?Sized {}
 
 #[cfg(test)]
 mod tests {
@@ -69,9 +69,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Arc;
     use tacacsrs_messages::enumerations::{
-        TacacsAccountingFlags, TacacsAccountingStatus, TacacsAuthenticationMethod,
-        TacacsAuthenticationService, TacacsAuthenticationType, TacacsMajorVersion,
-        TacacsMinorVersion, TacacsType,
+        TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType,
+        TacacsAuthorizationStatus, TacacsMajorVersion, TacacsMinorVersion, TacacsType,
     };
     use tacacsrs_messages::header::Header;
     use tacacsrs_messages::packet::Packet;
@@ -136,34 +135,41 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_send_accounting_request_flow() -> anyhow::Result<()> {
-        let request = AccountingRequest {
-            flags: TacacsAccountingFlags::START,
-            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
-            priv_lvl: 0,
-            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
-            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcNone,
+    fn authorization_request() -> AuthorizationRequest {
+        AuthorizationRequest {
+            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodTacacsplus,
+            priv_lvl: 15,
+            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeAscii,
+            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcLogin,
             user: "admin".to_owned(),
             port: "test".to_owned(),
             rem_address: "1.1.1.1".to_owned(),
-            args: vec!["service=shell".to_owned(), "cmd=test".to_owned()],
-        };
+            args: vec!["service=shell".to_owned(), "cmd=show".to_owned()],
+        }
+    }
 
-        let accounting_reply = AccountingReply {
-            status: TacacsAccountingStatus::TacPlusAcctStatusSuccess,
-            server_msg: "Test".to_owned(),
+    fn authorization_reply() -> AuthorizationReply {
+        AuthorizationReply {
+            status: TacacsAuthorizationStatus::TacPlusPassAdd,
+            server_msg: "Authorized".to_owned(),
             data: String::new(),
-        };
-        let reply_bytes = accounting_reply.to_bytes()?;
+            args: vec!["priv-lvl=15".to_owned()],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_authorization_request_flow() -> anyhow::Result<()> {
+        let request = authorization_request();
+        let authorization_reply = authorization_reply();
+        let reply_bytes = authorization_reply.to_bytes()?;
         let reply_length = u32::try_from(reply_bytes.len())
-            .map_err(|_| anyhow::Error::msg("Accounting reply payload exceeds u32 length"))?;
+            .map_err(|_| anyhow::Error::msg("Authorization reply payload exceeds u32 length"))?;
 
         let reply_packet = Packet::new(
             Header {
                 major_version: TacacsMajorVersion::TacacsPlusMajor1,
                 minor_version: TacacsMinorVersion::TacacsPlusMinorVerDefault,
-                tacacs_type: TacacsType::TacPlusAccounting,
+                tacacs_type: TacacsType::TacPlusAuthorisation,
                 seq_no: 2,
                 flags: TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG,
                 session_id: 42,
@@ -173,22 +179,23 @@ mod tests {
         )?;
 
         let io = TestIo::new(42, VecDeque::from([reply_packet]));
-        let reply = io.send_accounting_request(request).await?;
+        let reply = io.send_authorization_request(request).await?;
 
-        assert_eq!(reply.status, TacacsAccountingStatus::TacPlusAcctStatusSuccess);
+        assert_eq!(reply.status, TacacsAuthorizationStatus::TacPlusPassAdd);
+        assert_eq!(reply.args, vec!["priv-lvl=15"]);
 
         let sent_packets = io.sent_packets.lock().await;
         assert_eq!(sent_packets.len(), 1);
         assert_eq!(sent_packets[0].header().session_id, 42);
         assert_eq!(sent_packets[0].header().seq_no, 1);
-        assert_eq!(sent_packets[0].header().tacacs_type, TacacsType::TacPlusAccounting);
+        assert_eq!(sent_packets[0].header().tacacs_type, TacacsType::TacPlusAuthorisation);
         assert!(io.is_complete().await);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_send_accounting_request_with_session_adapter() -> anyhow::Result<()> {
+    async fn test_send_authorization_request_with_session_adapter() -> anyhow::Result<()> {
         let mock_transport = MockTransport::new();
         let mock_control = mock_transport.coordinator();
         let tacacs_connection = Arc::new(TacacsConnection::new(None));
@@ -196,45 +203,30 @@ mod tests {
 
         let session = tacacs_connection.create_session().await?;
         let session_id = session.session_id();
-
-        let request = AccountingRequest {
-            flags: TacacsAccountingFlags::START,
-            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodNone,
-            priv_lvl: 0,
-            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeNotSet,
-            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcNone,
-            user: "admin".to_owned(),
-            port: "test".to_owned(),
-            rem_address: "1.1.1.1".to_owned(),
-            args: vec!["service=shell".to_owned(), "cmd=test".to_owned()],
-        };
-
-        let accounting_reply = AccountingReply {
-            status: TacacsAccountingStatus::TacPlusAcctStatusSuccess,
-            server_msg: "Test".to_owned(),
-            data: String::new(),
-        };
+        let request = authorization_request();
+        let authorization_reply = authorization_reply();
 
         mock_control
-            .accounting_reply(&session, 2, &accounting_reply)
+            .authorization_reply(&session, 2, &authorization_reply)
             .send()
             .await?;
 
-        let reply = session.send_accounting_request(request).await?;
-        assert_eq!(reply.status, TacacsAccountingStatus::TacPlusAcctStatusSuccess);
+        let reply = session.send_authorization_request(request).await?;
+        assert_eq!(reply.status, TacacsAuthorizationStatus::TacPlusPassAdd);
+        assert_eq!(reply.args, vec!["priv-lvl=15"]);
         assert!(session.is_complete().await);
 
         let requests = mock_control.get_requests_for_session(session_id).await?;
         let sent_packet = requests
             .get(&1)
-            .ok_or_else(|| anyhow::Error::msg("Missing accounting request packet with seq 1"))?;
+            .ok_or_else(|| anyhow::Error::msg("Missing authorization request packet with seq 1"))?;
         assert_eq!(sent_packet.header().session_id, session_id);
         assert_eq!(sent_packet.header().seq_no, 1);
-        assert_eq!(sent_packet.header().tacacs_type, TacacsType::TacPlusAccounting);
+        assert_eq!(sent_packet.header().tacacs_type, TacacsType::TacPlusAuthorisation);
 
-        let sent_request = AccountingRequest::from_bytes(sent_packet.body())?;
+        let sent_request = AuthorizationRequest::from_bytes(sent_packet.body())?;
         assert_eq!(sent_request.user, "admin");
-        assert_eq!(sent_request.args, vec!["service=shell", "cmd=test"]);
+        assert_eq!(sent_request.args, vec!["service=shell", "cmd=show"]);
 
         Ok(())
     }

--- a/libraries/tacacsrs_flows/src/lib.rs
+++ b/libraries/tacacsrs_flows/src/lib.rs
@@ -11,3 +11,4 @@
 //! define minimal I/O traits and keep protocol state-machine logic in this crate.
 
 pub mod accounting;
+pub mod authorization;

--- a/libraries/tacacsrs_messages/src/accounting/reply.rs
+++ b/libraries/tacacsrs_messages/src/accounting/reply.rs
@@ -105,19 +105,21 @@ impl AccountingReply {
 }
 
 impl TacacsBodyTrait for AccountingReply {
-    fn to_bytes(&self) -> Vec<u8> {
-        // TACACS+ protocol encodes these lengths as u16 BE.
-        let server_msg_len =
-            u16::try_from(self.server_msg.len()).expect("server_msg exceeds 65535 bytes");
-        let data_len = u16::try_from(self.data.len()).expect("data exceeds 65535 bytes");
+    fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let server_msg_len = u16::try_from(self.server_msg.len())
+            .context("accounting reply server_msg exceeds 65535 bytes")?;
+        let data_len =
+            u16::try_from(self.data.len()).context("accounting reply data exceeds 65535 bytes")?;
 
-        let mut bytes = Vec::new();
+        let total = TACACS_ACCOUNTING_REPLY_MIN_LENGTH + self.server_msg.len() + self.data.len();
+
+        let mut bytes = Vec::with_capacity(total);
         bytes.extend(server_msg_len.to_be_bytes());
         bytes.extend(data_len.to_be_bytes());
         bytes.push(self.status as u8);
         bytes.extend(self.server_msg.as_bytes());
         bytes.extend(self.data.as_bytes());
-        bytes
+        Ok(bytes)
     }
 }
 
@@ -190,7 +192,7 @@ pub mod tests {
         let bytes = generate_accounting_reply_data();
         let reply = AccountingReply::from_bytes(&bytes).unwrap();
 
-        assert_eq!(reply.to_bytes(), bytes);
+        assert_eq!(reply.to_bytes().unwrap(), bytes);
     }
 
     #[test]

--- a/libraries/tacacsrs_messages/src/accounting/request.rs
+++ b/libraries/tacacsrs_messages/src/accounting/request.rs
@@ -235,29 +235,37 @@ impl AccountingRequest {
 }
 
 impl TacacsBodyTrait for AccountingRequest {
-    fn to_bytes(&self) -> Vec<u8> {
-        // TACACS+ protocol encodes these lengths as u8; panic on overflow
-        // rather than producing a silently malformed packet.
-        let user_len = u8::try_from(self.user.len()).expect("user field exceeds 255 bytes");
-        let port_len = u8::try_from(self.port.len()).expect("port field exceeds 255 bytes");
-        let rem_addr_len =
-            u8::try_from(self.rem_address.len()).expect("rem_address field exceeds 255 bytes");
-        let arg_cnt = u8::try_from(self.args.len()).expect("args count exceeds 255");
+    fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let user_len = u8::try_from(self.user.len())
+            .context("accounting request user field exceeds 255 bytes")?;
+        let port_len = u8::try_from(self.port.len())
+            .context("accounting request port field exceeds 255 bytes")?;
+        let rem_addr_len = u8::try_from(self.rem_address.len())
+            .context("accounting request rem_address field exceeds 255 bytes")?;
+        let arg_cnt =
+            u8::try_from(self.args.len()).context("accounting request args count exceeds 255")?;
 
-        let mut data = vec![
-            self.flags.bits(),
-            self.authen_method as u8,
-            self.priv_lvl,
-            self.authen_type as u8,
-            self.authen_service as u8,
-            user_len,
-            port_len,
-            rem_addr_len,
-            arg_cnt,
-        ];
+        let total = TACACS_ACCOUNTING_REQUEST_MIN_LENGTH
+            + self.args.len()
+            + self.user.len()
+            + self.port.len()
+            + self.rem_address.len()
+            + self.args.iter().map(String::len).sum::<usize>();
+
+        let mut data = Vec::with_capacity(total);
+        data.push(self.flags.bits());
+        data.push(self.authen_method as u8);
+        data.push(self.priv_lvl);
+        data.push(self.authen_type as u8);
+        data.push(self.authen_service as u8);
+        data.push(user_len);
+        data.push(port_len);
+        data.push(rem_addr_len);
+        data.push(arg_cnt);
 
         for arg in &self.args {
-            let arg_len = u8::try_from(arg.len()).expect("arg field exceeds 255 bytes");
+            let arg_len = u8::try_from(arg.len())
+                .context("accounting request arg field exceeds 255 bytes")?;
             data.push(arg_len);
         }
 
@@ -268,7 +276,7 @@ impl TacacsBodyTrait for AccountingRequest {
             data.extend(arg.as_bytes());
         }
 
-        data
+        Ok(data)
     }
 }
 
@@ -403,7 +411,7 @@ mod tests {
     fn test_to_data() {
         let data = generate_accounting_request_data();
         let accounting_request = AccountingRequest::from_bytes(data.as_slice()).unwrap();
-        let new_data = accounting_request.to_bytes();
+        let new_data = accounting_request.to_bytes().unwrap();
 
         assert_eq!(data, new_data);
     }
@@ -504,7 +512,7 @@ mod tests {
 
         let accounting_request = AccountingRequest::from_packet(&packet).unwrap();
 
-        assert_eq!(accounting_request.to_bytes(), packet.body().clone());
+        assert_eq!(accounting_request.to_bytes().unwrap(), packet.body().clone());
     }
 
     #[test]

--- a/libraries/tacacsrs_messages/src/authorization/mod.rs
+++ b/libraries/tacacsrs_messages/src/authorization/mod.rs
@@ -1,0 +1,2 @@
+pub mod reply;
+pub mod request;

--- a/libraries/tacacsrs_messages/src/authorization/reply.rs
+++ b/libraries/tacacsrs_messages/src/authorization/reply.rs
@@ -1,0 +1,185 @@
+use std::io::{Cursor, Read};
+
+use anyhow::Context;
+use byteorder::{BigEndian, ReadBytesExt};
+use num_enum::TryFromPrimitive;
+
+use crate::enumerations::TacacsAuthorizationStatus;
+use crate::traits::TacacsBodyTrait;
+
+const AUTHORIZATION_REPLY_MIN_LENGTH: usize = 6;
+const AUTHORIZATION_REPLY_ARG_SIZE_OFFSET: usize = 6;
+
+//  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8
+// +----------------+----------------+----------------+----------------+
+// |    status      |     arg_cnt    |         server_msg len          |
+// +----------------+----------------+----------------+----------------+
+// +            data_len             |    arg_1_len   |    arg_2_len   |
+// +----------------+----------------+----------------+----------------+
+// |      ...       |   arg_N_len    |         server_msg ...
+// +----------------+----------------+----------------+----------------+
+// |   data ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_1 ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_2 ...
+// +----------------+----------------+----------------+----------------+
+// |   ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_N ...
+// +----------------+----------------+----------------+----------------+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationReply {
+    pub status: TacacsAuthorizationStatus,
+    pub server_msg: String,
+    pub data: String,
+    pub args: Vec<String>,
+}
+
+impl AuthorizationReply {
+    fn size_from_bytes(data: &[u8]) -> anyhow::Result<usize> {
+        if data.len() < AUTHORIZATION_REPLY_MIN_LENGTH {
+            anyhow::bail!(
+                "body too short for authorization reply fixed fields: expected at least {}, actual {}",
+                AUTHORIZATION_REPLY_MIN_LENGTH,
+                data.len()
+            );
+        }
+
+        let arg_cnt = data[1] as usize;
+        let arg_sizes_end = AUTHORIZATION_REPLY_ARG_SIZE_OFFSET + arg_cnt;
+        if data.len() < arg_sizes_end {
+            anyhow::bail!(
+                "body too short for authorization reply argument size fields: expected at least {arg_sizes_end}, actual {}",
+                data.len()
+            );
+        }
+
+        let msg_len = usize::from(u16::from_be_bytes([data[2], data[3]]));
+        let data_len = usize::from(u16::from_be_bytes([data[4], data[5]]));
+        let arg_lengths = data[AUTHORIZATION_REPLY_ARG_SIZE_OFFSET..arg_sizes_end]
+            .iter()
+            .map(|length| usize::from(*length))
+            .sum::<usize>();
+
+        Ok(AUTHORIZATION_REPLY_MIN_LENGTH + arg_cnt + msg_len + data_len + arg_lengths)
+    }
+
+    fn read_string(cursor: &mut Cursor<&[u8]>, len: usize) -> anyhow::Result<String> {
+        #[allow(clippy::cast_possible_truncation)]
+        let remaining_buffer = cursor.get_ref().len() - cursor.position() as usize;
+        if remaining_buffer < len {
+            anyhow::bail!("not enough data to read authorization reply string");
+        }
+
+        let mut buffer = vec![0; len];
+        cursor
+            .read_exact(&mut buffer)
+            .with_context(|| format!("unable to read {len} authorization reply bytes"))?;
+
+        String::from_utf8(buffer).context("authorization reply string is not valid UTF-8")
+    }
+
+    /// # Errors
+    /// Returns an error if the data is too short or contains invalid field values.
+    pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
+        let expected_length = Self::size_from_bytes(data)?;
+        if data.len() < expected_length {
+            anyhow::bail!(
+                "data too short for authorization reply: expected {expected_length}, actual {}",
+                data.len()
+            );
+        }
+
+        let mut cursor = Cursor::new(data);
+        let status = TacacsAuthorizationStatus::try_from_primitive(
+            cursor
+                .read_u8()
+                .context("unable to read authorization status")?,
+        )
+        .context("invalid authorization status")?;
+        let arg_cnt = cursor.read_u8().context("unable to read arg_cnt")?;
+        let msg_len = cursor
+            .read_u16::<BigEndian>()
+            .context("unable to read msg_len")?;
+        let data_len = cursor
+            .read_u16::<BigEndian>()
+            .context("unable to read data_len")?;
+
+        let mut arg_sizes = Vec::with_capacity(usize::from(arg_cnt));
+        for _ in 0..arg_cnt {
+            arg_sizes.push(cursor.read_u8().context("unable to read arg size")?);
+        }
+
+        let server_msg = Self::read_string(&mut cursor, usize::from(msg_len))?;
+        let data = Self::read_string(&mut cursor, usize::from(data_len))?;
+        let mut args = Vec::with_capacity(arg_sizes.len());
+        for arg_size in arg_sizes {
+            args.push(Self::read_string(&mut cursor, usize::from(arg_size))?);
+        }
+
+        Ok(Self {
+            status,
+            server_msg,
+            data,
+            args,
+        })
+    }
+}
+
+impl TacacsBodyTrait for AuthorizationReply {
+    fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let arg_cnt =
+            u8::try_from(self.args.len()).context("authorization reply args count exceeds 255")?;
+        let msg_len = u16::try_from(self.server_msg.len())
+            .context("authorization reply server_msg exceeds 65535 bytes")?;
+        let data_len = u16::try_from(self.data.len())
+            .context("authorization reply data exceeds 65535 bytes")?;
+
+        let total = AUTHORIZATION_REPLY_MIN_LENGTH
+            + self.args.len()
+            + self.server_msg.len()
+            + self.data.len()
+            + self.args.iter().map(String::len).sum::<usize>();
+
+        let mut bytes = Vec::with_capacity(total);
+        bytes.push(self.status as u8);
+        bytes.push(arg_cnt);
+        bytes.extend(msg_len.to_be_bytes());
+        bytes.extend(data_len.to_be_bytes());
+
+        for arg in &self.args {
+            let arg_len = u8::try_from(arg.len())
+                .context("authorization reply arg field exceeds 255 bytes")?;
+            bytes.push(arg_len);
+        }
+
+        bytes.extend(self.server_msg.as_bytes());
+        bytes.extend(self.data.as_bytes());
+        for arg in &self.args {
+            bytes.extend(arg.as_bytes());
+        }
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorization_reply_round_trips() {
+        let reply = AuthorizationReply {
+            status: TacacsAuthorizationStatus::TacPlusPassAdd,
+            server_msg: "ok".to_owned(),
+            data: "display".to_owned(),
+            args: vec!["priv-lvl=15".to_owned()],
+        };
+
+        let decoded = AuthorizationReply::from_bytes(&reply.to_bytes().unwrap()).unwrap();
+
+        assert_eq!(decoded, reply);
+    }
+}

--- a/libraries/tacacsrs_messages/src/authorization/reply.rs
+++ b/libraries/tacacsrs_messages/src/authorization/reply.rs
@@ -1,10 +1,11 @@
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 
 use anyhow::Context;
 use byteorder::{BigEndian, ReadBytesExt};
 use num_enum::TryFromPrimitive;
 
 use crate::enumerations::TacacsAuthorizationStatus;
+use crate::helpers::read_string;
 use crate::traits::TacacsBodyTrait;
 
 const AUTHORIZATION_REPLY_MIN_LENGTH: usize = 6;
@@ -66,21 +67,6 @@ impl AuthorizationReply {
         Ok(AUTHORIZATION_REPLY_MIN_LENGTH + arg_cnt + msg_len + data_len + arg_lengths)
     }
 
-    fn read_string(cursor: &mut Cursor<&[u8]>, len: usize) -> anyhow::Result<String> {
-        #[allow(clippy::cast_possible_truncation)]
-        let remaining_buffer = cursor.get_ref().len() - cursor.position() as usize;
-        if remaining_buffer < len {
-            anyhow::bail!("not enough data to read authorization reply string");
-        }
-
-        let mut buffer = vec![0; len];
-        cursor
-            .read_exact(&mut buffer)
-            .with_context(|| format!("unable to read {len} authorization reply bytes"))?;
-
-        String::from_utf8(buffer).context("authorization reply string is not valid UTF-8")
-    }
-
     /// # Errors
     /// Returns an error if the data is too short or contains invalid field values.
     pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
@@ -112,11 +98,11 @@ impl AuthorizationReply {
             arg_sizes.push(cursor.read_u8().context("unable to read arg size")?);
         }
 
-        let server_msg = Self::read_string(&mut cursor, usize::from(msg_len))?;
-        let data = Self::read_string(&mut cursor, usize::from(data_len))?;
+        let server_msg = read_string(&mut cursor, usize::from(msg_len))?;
+        let data = read_string(&mut cursor, usize::from(data_len))?;
         let mut args = Vec::with_capacity(arg_sizes.len());
         for arg_size in arg_sizes {
-            args.push(Self::read_string(&mut cursor, usize::from(arg_size))?);
+            args.push(read_string(&mut cursor, usize::from(arg_size))?);
         }
 
         Ok(Self {

--- a/libraries/tacacsrs_messages/src/authorization/request.rs
+++ b/libraries/tacacsrs_messages/src/authorization/request.rs
@@ -1,0 +1,234 @@
+use std::io::{Cursor, Read};
+
+use anyhow::Context;
+use byteorder::ReadBytesExt;
+use num_enum::TryFromPrimitive;
+
+use crate::enumerations::{
+    TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType,
+};
+use crate::packet::{Packet, PacketTrait};
+use crate::traits::TacacsBodyTrait;
+
+const AUTHORIZATION_REQUEST_MIN_LENGTH: usize = 8;
+const AUTHORIZATION_ARG_SIZE_OFFSET: usize = 8;
+
+//  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8  1 2 3 4 5 6 7 8
+// +----------------+----------------+----------------+----------------+
+// | authen_method  |    priv_lvl    |  authen_type   | authen_service |
+// +----------------+----------------+----------------+----------------+
+// |    user_len    |    port_len    |  rem_addr_len  |    arg_cnt     |
+// +----------------+----------------+----------------+----------------+
+// |   arg_1_len    |   arg_2_len    |      ...       |   arg_N_len    |
+// +----------------+----------------+----------------+----------------+
+// |   user ...
+// +----------------+----------------+----------------+----------------+
+// |   port ...
+// +----------------+----------------+----------------+----------------+
+// |   rem_addr ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_1 ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_2 ...
+// +----------------+----------------+----------------+----------------+
+// |   ...
+// +----------------+----------------+----------------+----------------+
+// |   arg_N ...
+// +----------------+----------------+----------------+----------------+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationRequest {
+    pub authen_method: TacacsAuthenticationMethod,
+    pub priv_lvl: u8,
+    pub authen_type: TacacsAuthenticationType,
+    pub authen_service: TacacsAuthenticationService,
+    pub user: String,
+    pub port: String,
+    pub rem_address: String,
+    pub args: Vec<String>,
+}
+
+impl AuthorizationRequest {
+    /// # Errors
+    /// Returns an error if the packet body is too short or contains invalid fields.
+    pub fn from_packet(packet: &Packet) -> anyhow::Result<Self> {
+        let expected_length = Self::size_from_bytes(packet.body())
+            .context("unable to determine expected length of authorization request packet")?;
+        if packet.body().len() < expected_length {
+            anyhow::bail!(
+                "invalid authorization request body length: expected {expected_length}, actual {}",
+                packet.body().len()
+            );
+        }
+
+        Self::from_bytes(packet.body()).context("invalid TACACS+ authorization request")
+    }
+
+    fn size_from_bytes(data: &[u8]) -> anyhow::Result<usize> {
+        if data.len() < AUTHORIZATION_REQUEST_MIN_LENGTH {
+            anyhow::bail!(
+                "body too short for authorization request fixed fields: expected at least {}, actual {}",
+                AUTHORIZATION_REQUEST_MIN_LENGTH,
+                data.len()
+            );
+        }
+
+        let arg_cnt = data[7] as usize;
+        let arg_sizes_end = AUTHORIZATION_ARG_SIZE_OFFSET + arg_cnt;
+        if data.len() < arg_sizes_end {
+            anyhow::bail!(
+                "body too short for authorization argument size fields: expected at least {arg_sizes_end}, actual {}",
+                data.len()
+            );
+        }
+
+        let fixed_and_sizes = AUTHORIZATION_REQUEST_MIN_LENGTH + arg_cnt;
+        let string_lengths = usize::from(data[4])
+            + usize::from(data[5])
+            + usize::from(data[6])
+            + data[AUTHORIZATION_ARG_SIZE_OFFSET..arg_sizes_end]
+                .iter()
+                .map(|length| usize::from(*length))
+                .sum::<usize>();
+
+        Ok(fixed_and_sizes + string_lengths)
+    }
+
+    fn read_string(cursor: &mut Cursor<&[u8]>, len: usize) -> anyhow::Result<String> {
+        #[allow(clippy::cast_possible_truncation)]
+        let remaining_buffer = cursor.get_ref().len() - cursor.position() as usize;
+        if remaining_buffer < len {
+            anyhow::bail!("not enough data to read authorization string");
+        }
+
+        let mut buffer = vec![0; len];
+        cursor
+            .read_exact(&mut buffer)
+            .with_context(|| format!("unable to read {len} authorization bytes"))?;
+
+        String::from_utf8(buffer).context("authorization string is not valid UTF-8")
+    }
+
+    /// # Errors
+    /// Returns an error if the data is too short or contains invalid field values.
+    pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
+        let expected_length = Self::size_from_bytes(data)?;
+        if data.len() < expected_length {
+            anyhow::bail!(
+                "data too short for authorization request: expected {expected_length}, actual {}",
+                data.len()
+            );
+        }
+
+        let mut cursor = Cursor::new(data);
+        let authen_method = TacacsAuthenticationMethod::try_from_primitive(
+            cursor.read_u8().context("unable to read authen_method")?,
+        )
+        .context("invalid authorization authen_method")?;
+        let priv_lvl = cursor.read_u8().context("unable to read priv_lvl")?;
+        let authen_type = TacacsAuthenticationType::try_from_primitive(
+            cursor.read_u8().context("unable to read authen_type")?,
+        )
+        .context("invalid authorization authen_type")?;
+        let authen_service = TacacsAuthenticationService::try_from_primitive(
+            cursor.read_u8().context("unable to read authen_service")?,
+        )
+        .context("invalid authorization authen_service")?;
+        let user_len = cursor.read_u8().context("unable to read user_len")?;
+        let port_len = cursor.read_u8().context("unable to read port_len")?;
+        let rem_addr_len = cursor.read_u8().context("unable to read rem_addr_len")?;
+        let arg_cnt = cursor.read_u8().context("unable to read arg_cnt")?;
+
+        let mut arg_sizes = Vec::with_capacity(usize::from(arg_cnt));
+        for _ in 0..arg_cnt {
+            arg_sizes.push(cursor.read_u8().context("unable to read arg size")?);
+        }
+
+        let user = Self::read_string(&mut cursor, usize::from(user_len))?;
+        let port = Self::read_string(&mut cursor, usize::from(port_len))?;
+        let rem_address = Self::read_string(&mut cursor, usize::from(rem_addr_len))?;
+        let mut args = Vec::with_capacity(arg_sizes.len());
+        for arg_size in arg_sizes {
+            args.push(Self::read_string(&mut cursor, usize::from(arg_size))?);
+        }
+
+        Ok(Self {
+            authen_method,
+            priv_lvl,
+            authen_type,
+            authen_service,
+            user,
+            port,
+            rem_address,
+            args,
+        })
+    }
+}
+
+impl TacacsBodyTrait for AuthorizationRequest {
+    fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let user_len = u8::try_from(self.user.len())
+            .context("authorization request user field exceeds 255 bytes")?;
+        let port_len = u8::try_from(self.port.len())
+            .context("authorization request port field exceeds 255 bytes")?;
+        let rem_addr_len = u8::try_from(self.rem_address.len())
+            .context("authorization request rem_address field exceeds 255 bytes")?;
+        let arg_cnt = u8::try_from(self.args.len())
+            .context("authorization request args count exceeds 255")?;
+
+        let total = AUTHORIZATION_REQUEST_MIN_LENGTH
+            + self.args.len()
+            + self.user.len()
+            + self.port.len()
+            + self.rem_address.len()
+            + self.args.iter().map(String::len).sum::<usize>();
+
+        let mut data = Vec::with_capacity(total);
+        data.push(self.authen_method as u8);
+        data.push(self.priv_lvl);
+        data.push(self.authen_type as u8);
+        data.push(self.authen_service as u8);
+        data.push(user_len);
+        data.push(port_len);
+        data.push(rem_addr_len);
+        data.push(arg_cnt);
+
+        for arg in &self.args {
+            let arg_len = u8::try_from(arg.len())
+                .context("authorization request arg field exceeds 255 bytes")?;
+            data.push(arg_len);
+        }
+
+        data.extend(self.user.as_bytes());
+        data.extend(self.port.as_bytes());
+        data.extend(self.rem_address.as_bytes());
+        for arg in &self.args {
+            data.extend(arg.as_bytes());
+        }
+
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorization_request_round_trips() {
+        let request = AuthorizationRequest {
+            authen_method: TacacsAuthenticationMethod::TacPlusAuthenMethodTacacsplus,
+            priv_lvl: 15,
+            authen_type: TacacsAuthenticationType::TacPlusAuthenTypeAscii,
+            authen_service: TacacsAuthenticationService::TacPlusAuthenSvcLogin,
+            user: "admin".to_owned(),
+            port: "pts/0".to_owned(),
+            rem_address: "192.0.2.10".to_owned(),
+            args: vec!["service=shell".to_owned(), "cmd=show".to_owned()],
+        };
+
+        let decoded = AuthorizationRequest::from_bytes(&request.to_bytes().unwrap()).unwrap();
+
+        assert_eq!(decoded, request);
+    }
+}

--- a/libraries/tacacsrs_messages/src/authorization/request.rs
+++ b/libraries/tacacsrs_messages/src/authorization/request.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 
 use anyhow::Context;
 use byteorder::ReadBytesExt;
@@ -7,6 +7,7 @@ use num_enum::TryFromPrimitive;
 use crate::enumerations::{
     TacacsAuthenticationMethod, TacacsAuthenticationService, TacacsAuthenticationType,
 };
+use crate::helpers::read_string;
 use crate::packet::{Packet, PacketTrait};
 use crate::traits::TacacsBodyTrait;
 
@@ -94,21 +95,6 @@ impl AuthorizationRequest {
         Ok(fixed_and_sizes + string_lengths)
     }
 
-    fn read_string(cursor: &mut Cursor<&[u8]>, len: usize) -> anyhow::Result<String> {
-        #[allow(clippy::cast_possible_truncation)]
-        let remaining_buffer = cursor.get_ref().len() - cursor.position() as usize;
-        if remaining_buffer < len {
-            anyhow::bail!("not enough data to read authorization string");
-        }
-
-        let mut buffer = vec![0; len];
-        cursor
-            .read_exact(&mut buffer)
-            .with_context(|| format!("unable to read {len} authorization bytes"))?;
-
-        String::from_utf8(buffer).context("authorization string is not valid UTF-8")
-    }
-
     /// # Errors
     /// Returns an error if the data is too short or contains invalid field values.
     pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
@@ -144,12 +130,12 @@ impl AuthorizationRequest {
             arg_sizes.push(cursor.read_u8().context("unable to read arg size")?);
         }
 
-        let user = Self::read_string(&mut cursor, usize::from(user_len))?;
-        let port = Self::read_string(&mut cursor, usize::from(port_len))?;
-        let rem_address = Self::read_string(&mut cursor, usize::from(rem_addr_len))?;
+        let user = read_string(&mut cursor, usize::from(user_len))?;
+        let port = read_string(&mut cursor, usize::from(port_len))?;
+        let rem_address = read_string(&mut cursor, usize::from(rem_addr_len))?;
         let mut args = Vec::with_capacity(arg_sizes.len());
         for arg_size in arg_sizes {
-            args.push(Self::read_string(&mut cursor, usize::from(arg_size))?);
+            args.push(read_string(&mut cursor, usize::from(arg_size))?);
         }
 
         Ok(Self {

--- a/libraries/tacacsrs_messages/src/enumerations.rs
+++ b/libraries/tacacsrs_messages/src/enumerations.rs
@@ -11,7 +11,7 @@ pub enum TacacsMajorVersion {
 impl fmt::Display for TacacsMajorVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::TacacsPlusMajor1 => write!(f, "TACACS_PLUS_MAJOR_1"),
+            Self::TacacsPlusMajor1 => write!(f, "TAC_PLUS_MAJOR_VER"),
         }
     }
 }
@@ -27,9 +27,9 @@ impl fmt::Display for TacacsMinorVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TacacsPlusMinorVerDefault => {
-                write!(f, "TACACS_PLUS_MINOR_VER_DEFAULT")
+                write!(f, "TAC_PLUS_MINOR_VER_DEFAULT")
             }
-            Self::TacacsPlusMinorVerOne => write!(f, "TACACS_PLUS_MINOR_VER_ONE"),
+            Self::TacacsPlusMinorVerOne => write!(f, "TAC_PLUS_MINOR_VER_ONE"),
         }
     }
 }
@@ -286,23 +286,37 @@ impl fmt::Display for TacacsAuthenticationMethod {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u8)]
+/// TACACS+ authorization reply status octet values.
+///
+/// These values are carried in the `status` field of a TACACS+ authorization
+/// REPLY body as defined by RFC 8907 section 6.2.
 pub enum TacacsAuthorizationStatus {
+    /// `TAC_PLUS_AUTHOR_STATUS_PASS_ADD` (`0x01`) accepts the request and asks
+    /// the client to append the returned arguments to the submitted argument set.
     TacPlusPassAdd = 0x01,
+    /// `TAC_PLUS_AUTHOR_STATUS_PASS_REPL` (`0x02`) accepts the request and asks
+    /// the client to replace the submitted argument set with returned arguments.
     TacPlusPassRepl = 0x02,
+    /// `TAC_PLUS_AUTHOR_STATUS_FAIL` (`0x10`) denies the requested operation.
     TacPlusFail = 0x10,
+    /// `TAC_PLUS_AUTHOR_STATUS_ERROR` (`0x11`) reports that authorization could
+    /// not be completed because of a server-side or protocol processing error.
     TacPlusError = 0x11,
+    /// `TAC_PLUS_AUTHOR_STATUS_FOLLOW` (`0x21`) indicates deployment-specific
+    /// follow-up handling is needed.
     TacPlusFollow = 0x21,
 }
 
 impl fmt::Display for TacacsAuthorizationStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::TacPlusPassAdd => write!(f, "TAC_PLUS_PASS_ADD"),
-            Self::TacPlusPassRepl => write!(f, "TAC_PLUS_PASS_REPL"),
-            Self::TacPlusFail => write!(f, "TAC_PLUS_FAIL"),
-            Self::TacPlusError => write!(f, "TAC_PLUS_ERROR"),
-            Self::TacPlusFollow => write!(f, "TAC_PLUS_FOLLOW"),
+            Self::TacPlusPassAdd => write!(f, "TAC_PLUS_AUTHOR_STATUS_PASS_ADD"),
+            Self::TacPlusPassRepl => write!(f, "TAC_PLUS_AUTHOR_STATUS_PASS_REPL"),
+            Self::TacPlusFail => write!(f, "TAC_PLUS_AUTHOR_STATUS_FAIL"),
+            Self::TacPlusError => write!(f, "TAC_PLUS_AUTHOR_STATUS_ERROR"),
+            Self::TacPlusFollow => write!(f, "TAC_PLUS_AUTHOR_STATUS_FOLLOW"),
         }
     }
 }

--- a/libraries/tacacsrs_messages/src/lib.rs
+++ b/libraries/tacacsrs_messages/src/lib.rs
@@ -3,6 +3,7 @@ pub mod packet;
 pub mod constants;
 pub mod enumerations;
 pub mod accounting;
+pub mod authorization;
 pub mod traits;
 mod helpers;
 mod obfuscation;

--- a/libraries/tacacsrs_messages/src/traits.rs
+++ b/libraries/tacacsrs_messages/src/traits.rs
@@ -1,3 +1,7 @@
 pub trait TacacsBodyTrait {
-    fn to_bytes(&self) -> Vec<u8>;
+    /// Serializes this message body to its TACACS+ wire representation.
+    ///
+    /// # Errors
+    /// Returns an error if a field value exceeds the protocol length limit.
+    fn to_bytes(&self) -> anyhow::Result<Vec<u8>>;
 }

--- a/libraries/tacacsrs_networking/examples/mock_connection.rs
+++ b/libraries/tacacsrs_networking/examples/mock_connection.rs
@@ -74,7 +74,7 @@ async fn send_accounting_request(
         ));
     }
     let sequence_number = session.next_sequence_number().await;
-    let data = request.to_bytes();
+    let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
         .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
     let packet = Packet::new(

--- a/libraries/tacacsrs_networking/examples/multiple_transactions.rs
+++ b/libraries/tacacsrs_networking/examples/multiple_transactions.rs
@@ -102,7 +102,7 @@ async fn send_accounting_request(
         ));
     }
     let sequence_number = session.next_sequence_number().await;
-    let data = request.to_bytes();
+    let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
         .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
     let packet = Packet::new(

--- a/libraries/tacacsrs_networking/examples/single_transaction.rs
+++ b/libraries/tacacsrs_networking/examples/single_transaction.rs
@@ -102,7 +102,7 @@ async fn send_accounting_request(
         ));
     }
     let sequence_number = session.next_sequence_number().await;
-    let data = request.to_bytes();
+    let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
         .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
 

--- a/libraries/tacacsrs_networking/examples/tls_client.rs
+++ b/libraries/tacacsrs_networking/examples/tls_client.rs
@@ -123,7 +123,7 @@ async fn send_accounting_request(
         return Err(anyhow::Error::msg("Cannot send accounting request on a completed session"));
     }
     let sequence_number = session.next_sequence_number().await;
-    let data = request.to_bytes();
+    let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
         .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
     let packet = Packet::new(

--- a/libraries/tacacsrs_networking/examples/tls_psk_client.rs
+++ b/libraries/tacacsrs_networking/examples/tls_psk_client.rs
@@ -89,7 +89,7 @@ async fn send_accounting_request(
         ));
     }
     let sequence_number = session.next_sequence_number().await;
-    let data = request.to_bytes();
+    let data = request.to_bytes()?;
     let length = u32::try_from(data.len())
         .map_err(|_| anyhow::Error::msg("Accounting request payload exceeds u32 length"))?;
     let packet = Packet::new(

--- a/libraries/tacacsrs_networking/src/transport/mock/mock_transport_coordinator.rs
+++ b/libraries/tacacsrs_networking/src/transport/mock/mock_transport_coordinator.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 
 use tacacsrs_messages::accounting::reply::AccountingReply;
+use tacacsrs_messages::authorization::reply::AuthorizationReply;
 use tacacsrs_messages::enumerations::{TacacsFlags, TacacsMajorVersion, TacacsMinorVersion, TacacsType};
 use tacacsrs_messages::header::Header;
 use tacacsrs_messages::packet::{Packet, PacketTrait};
@@ -100,12 +101,118 @@ impl<'a> MockAccountingReplyBuilder<'a> {
     /// Returns an error if the reply packet cannot be constructed.
     #[allow(clippy::cast_possible_truncation)] // body length bounded by u16 field sizes
     pub fn build(self) -> anyhow::Result<Packet> {
-        let data = self.reply.to_bytes();
+        let data = self.reply.to_bytes()?;
         let mut packet = Packet::new(
             Header {
                 major_version: TacacsMajorVersion::TacacsPlusMajor1,
                 minor_version: TacacsMinorVersion::TacacsPlusMinorVerDefault,
                 tacacs_type: TacacsType::TacPlusAccounting,
+                seq_no: self.seq_no,
+                flags: self.flags,
+                session_id: self.session_id,
+                length: data.len() as u32,
+            },
+            data,
+        )?;
+
+        if let Some(key) = self.obfuscation_key {
+            packet = packet.to_obfuscated(key);
+        }
+
+        Ok(packet)
+    }
+}
+
+/// Builder for registering authorization reply packets on a [`MockTransportCoordinator`].
+///
+/// Created via [`MockTransportCoordinator::authorization_reply`] or
+/// [`MockTransportCoordinator::authorization_reply_for_id`]. Call [`send`](Self::send)
+/// to finalize construction and register the reply.
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | `flags` | [`TAC_PLUS_UNENCRYPTED_FLAG`](TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG) |
+/// | `delay` | `None` (immediate) |
+/// | `obfuscation_key` | `None` (plaintext) |
+pub struct MockAuthorizationReplyBuilder<'a> {
+    coordinator: &'a MockTransportCoordinator,
+    session_id: u32,
+    seq_no: u8,
+    reply: &'a AuthorizationReply,
+    flags: TacacsFlags,
+    delay: Option<Duration>,
+    obfuscation_key: Option<&'a [u8]>,
+}
+
+impl<'a> MockAuthorizationReplyBuilder<'a> {
+    /// Overrides the default flags on the reply packet header.
+    ///
+    /// By default the builder uses [`TAC_PLUS_UNENCRYPTED_FLAG`](TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG).
+    /// Calling this **replaces** the flags entirely.
+    #[must_use]
+    pub const fn with_flags(mut self, flags: TacacsFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Adds [`TAC_PLUS_SINGLE_CONNECT_FLAG`](TacacsFlags::TAC_PLUS_SINGLE_CONNECT_FLAG)
+    /// to the reply packet header flags.
+    #[must_use]
+    pub fn with_single_connect(mut self) -> Self {
+        self.flags |= TacacsFlags::TAC_PLUS_SINGLE_CONNECT_FLAG;
+        self
+    }
+
+    /// Delivers the reply after `delay` instead of immediately.
+    #[must_use]
+    pub const fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
+        self
+    }
+
+    /// Obfuscates the reply packet before registering it.
+    ///
+    /// The mock transport replays raw bytes without deobfuscation, so
+    /// an obfuscated reply must be pre-obfuscated to match what a real
+    /// TACACS+ server would send.
+    #[must_use]
+    pub const fn with_obfuscation_key(mut self, key: &'a [u8]) -> Self {
+        self.obfuscation_key = Some(key);
+        self
+    }
+
+    /// Builds the authorization reply packet and registers it on the coordinator.
+    /// # Errors
+    /// Returns an error if the reply packet cannot be constructed.
+    pub async fn send(self) -> anyhow::Result<()> {
+        let coordinator = self.coordinator;
+        let delay = self.delay;
+        let packet = self.build()?;
+
+        if let Some(delay) = delay {
+            coordinator.add_reply_with_delay(packet, delay).await
+        } else {
+            coordinator.add_reply(packet).await
+        }
+    }
+
+    /// Builds the authorization reply packet and returns it without registering.
+    ///
+    /// This is useful when a test needs to register the packet under a
+    /// different session ID or sequence number than the one in the header
+    /// (e.g. to test header-mismatch error handling).
+    /// # Errors
+    /// Returns an error if the reply packet cannot be constructed.
+    #[allow(clippy::cast_possible_truncation)] // body length bounded by reply field sizes
+    pub fn build(self) -> anyhow::Result<Packet> {
+        let data = self.reply.to_bytes()?;
+        let mut packet = Packet::new(
+            Header {
+                major_version: TacacsMajorVersion::TacacsPlusMajor1,
+                minor_version: TacacsMinorVersion::TacacsPlusMinorVerDefault,
+                tacacs_type: TacacsType::TacPlusAuthorisation,
                 seq_no: self.seq_no,
                 flags: self.flags,
                 session_id: self.session_id,
@@ -257,6 +364,56 @@ impl MockTransportCoordinator {
         reply: &'a AccountingReply,
     ) -> MockAccountingReplyBuilder<'a> {
         MockAccountingReplyBuilder {
+            coordinator: self,
+            session_id,
+            seq_no: reply_sequence_number,
+            reply,
+            flags: TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG,
+            delay: None,
+            obfuscation_key: None,
+        }
+    }
+
+    /// Creates a [`MockAuthorizationReplyBuilder`] for registering an authorization
+    /// reply associated with the given session.
+    ///
+    /// # Arguments
+    ///
+    /// * `session` - provides the session ID for the reply.
+    /// * `reply_sequence_number` - the sequence number for the reply.
+    /// * `reply` - the authorization reply body.
+    pub const fn authorization_reply<'a>(
+        &'a self,
+        session: &Session,
+        reply_sequence_number: u8,
+        reply: &'a AuthorizationReply,
+    ) -> MockAuthorizationReplyBuilder<'a> {
+        MockAuthorizationReplyBuilder {
+            coordinator: self,
+            session_id: session.session_id(),
+            seq_no: reply_sequence_number,
+            reply,
+            flags: TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG,
+            delay: None,
+            obfuscation_key: None,
+        }
+    }
+
+    /// Creates a [`MockAuthorizationReplyBuilder`] for registering an authorization
+    /// reply for a known `session_id`.
+    ///
+    /// This is the counterpart of [`authorization_reply`](Self::authorization_reply)
+    /// for callers that do not have a [`Session`] reference - e.g. when
+    /// testing [`DedicatedConnection`](crate::DedicatedConnection) with a
+    /// predetermined session ID.
+    #[must_use]
+    pub const fn authorization_reply_for_id<'a>(
+        &'a self,
+        session_id: u32,
+        reply_sequence_number: u8,
+        reply: &'a AuthorizationReply,
+    ) -> MockAuthorizationReplyBuilder<'a> {
+        MockAuthorizationReplyBuilder {
             coordinator: self,
             session_id,
             seq_no: reply_sequence_number,

--- a/libraries/tacacsrs_networking/src/transport/mock/mod.rs
+++ b/libraries/tacacsrs_networking/src/transport/mock/mod.rs
@@ -88,4 +88,6 @@ mod mock_transport_coordinator;
 mod mock_write_half;
 
 pub use mock_transport::MockTransport;
-pub use mock_transport_coordinator::{MockAccountingReplyBuilder, MockTransportCoordinator};
+pub use mock_transport_coordinator::{
+    MockAccountingReplyBuilder, MockAuthorizationReplyBuilder, MockTransportCoordinator,
+};


### PR DESCRIPTION
- Introduced `AuthorizationRequest` and `AuthorizationReply` structs to handle TACACS+ authorization messages.
- Implemented serialization and deserialization for both request and reply types, ensuring compliance with the TACACS+ protocol.
- Updated the `TacacsBodyTrait` to return `anyhow::Result<Vec<u8>>` for better error handling during serialization.
- Added tests for round-trip serialization of authorization request and reply messages.
- Enhanced mock transport coordinator to support authorization replies, allowing for easier testing of authorization flows.
- Updated relevant examples to utilize the new authorization request and reply functionalities.