### PR TITLE
feat: add base64 support for TLS 1.3 PSK authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,6 +2133,7 @@ name = "tacon"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "clap_mangen",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -222,9 +228,9 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -423,6 +429,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -1016,10 +1054,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1029,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1066,7 +1105,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e5310a2c5b6ffbc094b5f70a2ca7b79ed36ad90e6f90994b166489a1bce3fcc"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "libseccomp-sys",
  "pkg-config",
@@ -1101,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -1253,7 +1292,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1406,6 +1445,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,7 +1598,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -1591,9 +1652,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redis"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
+checksum = "bae41a63fd0b8a5372f82b21e810e09a316f5dd7efd96bf08e678fb240fc1918"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -1618,7 +1679,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1693,7 +1754,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2035,7 +2096,7 @@ version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -2081,7 +2142,7 @@ name = "tacacsrs-messages"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "md-5",
  "num_enum",

--- a/executables/tacon/Cargo.toml
+++ b/executables/tacon/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.102", features = ["backtrace"] }
+base64 = { version = "0.22", optional = true }
 clap = { version = "4.6.1", features = ["derive"] }
 env_logger = "0.11.10"
 futures = "0.3"
@@ -27,7 +28,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 default = []
-psk = ["tacacsrs-networking/psk"]
+psk = ["dep:base64", "tacacsrs-networking/psk"]
 
 [build-dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/executables/tacon/src/cli.rs
+++ b/executables/tacon/src/cli.rs
@@ -110,7 +110,7 @@ pub struct Cli {
     #[arg(long, value_name = "IDENTITY", requires_all = ["use_tls", "psk_key"], conflicts_with_all = ["client_certificate", "client_key", "service_endpoint"])]
     pub psk_identity: Option<String>,
 
-    /// Pre-shared key for TLS 1.3 PSK authentication
+    /// Base64-encoded pre-shared key for TLS 1.3 PSK authentication
     #[cfg(feature = "psk")]
     #[arg(long, value_name = "KEY", requires_all = ["use_tls", "psk_identity"], conflicts_with_all = ["client_certificate", "client_key", "service_endpoint"])]
     pub psk_key: Option<String>,

--- a/executables/tacon/src/config.rs
+++ b/executables/tacon/src/config.rs
@@ -1,4 +1,6 @@
 use anyhow::Context;
+#[cfg(feature = "psk")]
+use base64::Engine as _;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
 use tacacsrs_config::{
     TacacsPlus, TacacsPlusBuilder, TacacsPlusServer, TacacsPlusServerBuilder, TacacsPlusServerExt,
@@ -154,12 +156,8 @@ fn populate_security_from_cli(
         if let (Some(psk_identity), Some(psk_key)) =
             (cli.psk_identity.as_ref(), cli.psk_key.as_ref())
         {
-            let tls_builder = apply_psk_key_exchange(
-                cli,
-                builder,
-                psk_identity.clone(),
-                psk_key.as_bytes().to_vec(),
-            )?;
+            let psk_key = decode_cli_psk_key(psk_key)?;
+            let tls_builder = apply_psk_key_exchange(cli, builder, psk_identity.clone(), psk_key)?;
 
             if options.allows(&ValidationRelaxation::AllowTlsWithSharedSecret) {
                 if let Some(ref secret) = cli.shared_secret {
@@ -222,6 +220,13 @@ fn populate_security_from_cli(
             None => builder.build(),
         })
     }
+}
+
+#[cfg(feature = "psk")]
+fn decode_cli_psk_key(psk_key: &str) -> anyhow::Result<Vec<u8>> {
+    base64::engine::general_purpose::STANDARD
+        .decode(psk_key)
+        .context("--psk-key must be standard base64-encoded PSK bytes")
 }
 
 #[cfg(feature = "psk")]
@@ -754,6 +759,21 @@ mod tests {
     }
 
     #[cfg(feature = "psk")]
+    fn tls13_epsk_key(cli: &Cli) -> Vec<u8> {
+        let mut root = tacacs_plus_from_cli(cli).expect("PSK config should build");
+        root.server
+            .remove(0)
+            .client_identity
+            .expect("client identity")
+            .tls13_epsk
+            .expect("tls13 epsk")
+            .inline_definition
+            .expect("inline key")
+            .cleartext_symmetric_key
+            .expect("symmetric key")
+    }
+
+    #[cfg(feature = "psk")]
     #[test]
     fn tacacs_plus_from_cli_defaults_psk_to_dhe_groups() {
         let cli = Cli::parse_from([
@@ -764,7 +784,7 @@ mod tests {
             "--psk-identity",
             "client",
             "--psk-key",
-            "secret",
+            "c2VjcmV0",
             "accounting",
             "--user",
             "alice",
@@ -783,6 +803,60 @@ mod tests {
 
     #[cfg(feature = "psk")]
     #[test]
+    fn tacacs_plus_from_cli_decodes_base64_psk_key() {
+        let cli = Cli::parse_from([
+            "tacon",
+            "--server-addr",
+            "192.0.2.10:49",
+            "--use-tls",
+            "--psk-identity",
+            "client",
+            "--psk-key",
+            "c2VjcmV0",
+            "accounting",
+            "--user",
+            "alice",
+            "--port",
+            "tty0",
+            "--rem-addr",
+            "192.0.2.50",
+            "show",
+        ]);
+
+        assert_eq!(tls13_epsk_key(&cli), b"secret");
+    }
+
+    #[cfg(feature = "psk")]
+    #[test]
+    fn tacacs_plus_from_cli_rejects_invalid_base64_psk_key() {
+        let cli = Cli::parse_from([
+            "tacon",
+            "--server-addr",
+            "192.0.2.10:49",
+            "--use-tls",
+            "--psk-identity",
+            "client",
+            "--psk-key",
+            "not base64!!!",
+            "accounting",
+            "--user",
+            "alice",
+            "--port",
+            "tty0",
+            "--rem-addr",
+            "192.0.2.50",
+            "show",
+        ]);
+
+        let error = tacacs_plus_from_cli(&cli).expect_err("invalid base64 PSK should fail");
+
+        assert!(error
+            .to_string()
+            .contains("--psk-key must be standard base64-encoded PSK bytes"));
+    }
+
+    #[cfg(feature = "psk")]
+    #[test]
     fn tacacs_plus_from_cli_allows_psk_only_mode() {
         let cli = Cli::parse_from([
             "tacon",
@@ -792,7 +866,7 @@ mod tests {
             "--psk-identity",
             "client",
             "--psk-key",
-            "secret",
+            "c2VjcmV0",
             "--psk-key-exchange",
             "psk-only",
             "accounting",
@@ -819,7 +893,7 @@ mod tests {
             "--psk-identity",
             "client",
             "--psk-key",
-            "secret",
+            "c2VjcmV0",
             "--psk-key-exchange-groups",
             "secp256r1,x25519",
             "accounting",
@@ -849,7 +923,7 @@ mod tests {
             "--psk-identity",
             "client",
             "--psk-key",
-            "secret",
+            "c2VjcmV0",
             "--psk-key-exchange",
             "psk-only",
             "--psk-key-exchange-groups",


### PR DESCRIPTION
This pull request updates the handling of pre-shared keys (PSK) for TLS 1.3 in the `tacon` executable. The main improvement is that the PSK key must now be provided as a standard base64-encoded string, which is then decoded before use. This change affects both the command-line interface and the internal configuration logic, and is accompanied by updated tests to ensure correct behavior and error handling.

Key changes include:

**PSK Key Handling and Decoding:**
- The `--psk-key` CLI argument is now documented and required to be a base64-encoded string. The code decodes this value before using it for TLS 1.3 PSK authentication, improving security and interoperability. [[1]](diffhunk://#diff-4d2c4dc1c2ce95e251cf97f0d6555f2984bb742a8f58533167464dfc7f1fb9feL113-R113) [[2]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdL157-R160)
- A new helper function `decode_cli_psk_key` is introduced to perform base64 decoding and provide a clear error message if decoding fails.
- The `base64` crate is added as an optional dependency, enabled only when the `psk` feature is active, and the feature configuration is updated to reflect this. [[1]](diffhunk://#diff-e8502cc83ac40cabc2f0ab68a59c368643b1c7c8900c1995017e6cf333802455R14) [[2]](diffhunk://#diff-e8502cc83ac40cabc2f0ab68a59c368643b1c7c8900c1995017e6cf333802455L30-R31) [[3]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdR2-R3)

**Testing and Validation:**
- All affected tests are updated to use base64-encoded PSK values (e.g., `"c2VjcmV0"` for `"secret"`), ensuring that the new decoding logic is exercised. [[1]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdL767-R787) [[2]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdL795-R869) [[3]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdL822-R896) [[4]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdL852-R926)
- New tests are added to verify that valid base64 keys are correctly decoded and that invalid base64 input is properly rejected with a clear error message. [[1]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdR761-R775) [[2]](diffhunk://#diff-aed145fcb6a981c410256e1e4ed45761ef8958cc027e6a3aa084e7bdfe0be5cdR804-R857)

These changes make PSK usage more robust and user-friendly by enforcing base64 encoding and providing better error reporting.