### PR TITLE
feat: add dedicated connection option to TACACS+ agent, fix per-hop proxy

### DIFF
--- a/executables/tacacsrs_agentd/src/cli.rs
+++ b/executables/tacacsrs_agentd/src/cli.rs
@@ -40,6 +40,7 @@ fn psk_dhe_ke_supported_group_parser(
         })
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Parser)]
 #[command(name = "tacacsrs-agentd", version, author)]
 #[command(about = "Central TACACS+ client service for local consumers")]
@@ -55,6 +56,7 @@ pub(crate) struct Cli {
         "server_addresses", "shared_secret", "use_tls",
         "client_certificate", "client_key",
         "insecure_disable_certificate_verification",
+        "dedicated",
         "sonic", "sonic_redis_url", "sonic_redis_db",
     ])]
     pub(crate) config: Option<PathBuf>,
@@ -118,6 +120,10 @@ pub(crate) struct Cli {
     /// Timeout, in seconds, for establishing a new upstream TACACS+ connection.
     #[arg(long, default_value_t = 5)]
     pub(crate) connect_timeout_seconds: u64,
+
+    /// Use a dedicated upstream connection per request instead of TACACS+ single-connection mode.
+    #[arg(long, requires = "server_addresses", conflicts_with = "sonic")]
+    pub(crate) dedicated: bool,
 
     /// Probe interval, in seconds, used when checking whether the preferred server has recovered.
     #[arg(long, default_value_t = 30)]

--- a/executables/tacacsrs_agentd/src/main.rs
+++ b/executables/tacacsrs_agentd/src/main.rs
@@ -154,7 +154,7 @@ fn tacacs_plus_from_cli(cli: &Cli) -> anyhow::Result<TacacsPlus> {
                 .iter()
                 .enumerate()
                 .map(|(i, addr)| {
-                    let builder = base_server_builder_from_address(addr, i, timeout);
+                    let builder = base_server_builder_from_address(addr, i, timeout, cli.dedicated);
                     match cli.psk_key_exchange {
                         Some(PskKeyExchange::PskOnly) => builder.with_tls13_epsk_psk_only(
                             psk_identity.clone(),
@@ -186,9 +186,11 @@ fn tacacs_plus_from_cli(cli: &Cli) -> anyhow::Result<TacacsPlus> {
             .iter()
             .enumerate()
             .map(|(i, addr)| match cli.shared_secret.clone() {
-                Some(shared_secret) => base_server_builder_from_address(addr, i, timeout)
-                    .with_shared_secret(shared_secret),
-                None => base_server_builder_from_address(addr, i, timeout),
+                Some(shared_secret) => {
+                    base_server_builder_from_address(addr, i, timeout, cli.dedicated)
+                        .with_shared_secret(shared_secret)
+                }
+                None => base_server_builder_from_address(addr, i, timeout, cli.dedicated),
             })
             .collect()
     };
@@ -236,14 +238,15 @@ fn tls_cert_server_builders_from_cli(
         .enumerate()
         .map(|(i, addr)| {
             if client_cert_der.is_some() || client_key_der.is_some() {
-                base_server_builder_from_address(addr, i, timeout)
+                base_server_builder_from_address(addr, i, timeout, cli.dedicated)
                     .with_tls_client_certificate_with_key_format(
                         client_cert_der.clone(),
                         client_key_der.clone(),
                         client_key_format,
                     )
             } else {
-                base_server_builder_from_address(addr, i, timeout).with_tls_server_authentication()
+                base_server_builder_from_address(addr, i, timeout, cli.dedicated)
+                    .with_tls_server_authentication()
             }
         })
         .collect())
@@ -253,11 +256,13 @@ fn base_server_builder_from_address(
     addr: &str,
     index: usize,
     timeout: u16,
+    dedicated: bool,
 ) -> TacacsPlusServerBuilder {
     let (host, port) = parse_host_port(addr, 49);
 
     TacacsPlusServerBuilder::new(format!("server-{index}"), TacacsPlusServerType::all(), host, port)
         .with_timeout(timeout)
+        .with_single_connection(!dedicated)
 }
 
 fn enabled_services_from_cli(cli: &Cli) -> EnabledServices {
@@ -590,6 +595,35 @@ mod tests {
 
         let root = tacacs_plus_from_cli(&cli).expect("plain-text shared secret should load");
         assert_eq!(root.server[0].shared_secret.as_deref(), Some("secret1"));
+    }
+
+    #[test]
+    fn tacacs_plus_from_cli_enables_single_connection_negotiation() {
+        let cli = Cli::parse_from([
+            "tacacsrs-agentd",
+            "--server-addr",
+            "192.0.2.20:49",
+            "--shared-secret",
+            "secret1",
+        ]);
+
+        let root = tacacs_plus_from_cli(&cli).expect("CLI config should load");
+        assert!(root.server[0].single_connection);
+    }
+
+    #[test]
+    fn tacacs_plus_from_cli_dedicated_disables_single_connection_negotiation() {
+        let cli = Cli::parse_from([
+            "tacacsrs-agentd",
+            "--server-addr",
+            "192.0.2.20:49",
+            "--shared-secret",
+            "secret1",
+            "--dedicated",
+        ]);
+
+        let root = tacacs_plus_from_cli(&cli).expect("CLI config should load");
+        assert!(!root.server[0].single_connection);
     }
 
     #[test]

--- a/libraries/tacacsrs_agent/src/services/tacacs_proxy/upstream_bridge/mod.rs
+++ b/libraries/tacacsrs_agent/src/services/tacacs_proxy/upstream_bridge/mod.rs
@@ -7,14 +7,11 @@ use anyhow::Context;
 use tacacsrs_config::TacacsPlusServer;
 use tacacsrs_flow_abstractions::client_session_flow_io::ClientSessionFlowIoTrait;
 use tacacsrs_messages::packet::PacketTrait;
-use tacacsrs_networking::{PacketReader, PacketWriter};
+use tacacsrs_networking::PacketWriter;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use self::error::ProxyConnectionError;
-use self::packet_io::{
-    read_downstream_packet, read_upstream_packet, validate_downstream_obfuscation,
-    write_downstream_packet,
-};
+use self::packet_io::{read_downstream_packet, read_upstream_packet, write_downstream_packet};
 use self::reply_action::{ReplyAction, reply_action};
 use self::session_mapping::rewrite_session_id;
 use crate::runtime::RequestGuard;
@@ -46,13 +43,16 @@ impl UpstreamBridge {
     where
         Stream: AsyncRead + AsyncWrite + Unpin + Send,
     {
-        let bound_server = self
-            .upstream_manager
-            .bind_server_for_new_session()
-            .await
-            .with_context(|| {
-                format!("Failed to bind TACACS+ proxy client {peer_label} to an upstream server")
-            })?;
+        let bound_server = match self.upstream_manager.bind_server_for_new_session().await {
+            Ok(bound_server) => bound_server,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to bind TACACS+ proxy client {peer_label} to an upstream server"
+                    )
+                });
+            }
+        };
 
         log::debug!(
             "Proxying TACACS+ client {peer_label} via {} (server index {})",
@@ -60,7 +60,9 @@ impl UpstreamBridge {
             bound_server.index,
         );
 
-        match proxy_bound_connection(stream, &bound_server).await {
+        let result = proxy_bound_connection(stream, &bound_server).await;
+
+        match result {
             Ok(()) => Ok(()),
             Err(ProxyConnectionError::Upstream(error)) => {
                 self.upstream_manager
@@ -86,13 +88,14 @@ where
         .shared_secret
         .as_ref()
         .map(|secret| secret.as_bytes().to_vec());
-    let upstream_session = bound_server
-        .connection
-        .create_raw_session()
-        .await
-        .map_err(|error| {
-            ProxyConnectionError::Upstream(error.context("Failed to create upstream proxy session"))
-        })?;
+    let upstream_session = match bound_server.connection.create_raw_session().await {
+        Ok(upstream_session) => upstream_session,
+        Err(error) => {
+            return Err(ProxyConnectionError::Upstream(
+                error.context("Failed to create upstream proxy session"),
+            ));
+        }
+    };
 
     proxy_connection_with_session(stream, server, timeout, obfuscation_key, &upstream_session).await
 }
@@ -108,11 +111,9 @@ where
     Stream: AsyncRead + AsyncWrite + Unpin + Send,
     Session: ClientSessionFlowIoTrait + Sync + ?Sized,
 {
-    let reader = PacketReader::new(obfuscation_key.clone());
     let writer = PacketWriter::new(obfuscation_key);
     let result =
-        proxy_connection_loop(&mut stream, server, timeout, &reader, &writer, upstream_session)
-            .await;
+        proxy_connection_loop(&mut stream, server, timeout, &writer, upstream_session).await;
 
     upstream_session.complete().await;
     result
@@ -122,7 +123,6 @@ async fn proxy_connection_loop<Stream, Session>(
     stream: &mut Stream,
     server: &TacacsPlusServer,
     timeout: Duration,
-    reader: &PacketReader,
     writer: &PacketWriter,
     upstream_session: &Session,
 ) -> Result<(), ProxyConnectionError>
@@ -134,8 +134,18 @@ where
     let upstream_session_id = upstream_session.session_id();
 
     loop {
-        let downstream_packet = read_downstream_packet(reader, stream, timeout).await?;
-        validate_downstream_obfuscation(&downstream_packet, server)?;
+        let downstream_packet = match read_downstream_packet(
+            stream,
+            timeout,
+            server.shared_secret.as_ref().map(String::as_bytes),
+        )
+        .await
+        {
+            Ok(packet) => packet,
+            Err(error) => return Err(error),
+        };
+        let downstream_reply_obfuscation = downstream_packet.reply_obfuscation;
+        let downstream_packet = downstream_packet.packet;
 
         let packet_session_id = downstream_packet.header().session_id;
         match downstream_session_id {
@@ -151,22 +161,31 @@ where
         }
 
         let downstream_session_id = downstream_session_id.expect("session id was just set");
-        let upstream_packet = rewrite_session_id(downstream_packet, upstream_session_id)
-            .map_err(ProxyConnectionError::Downstream)?;
-        upstream_session
-            .send_packet(upstream_packet)
-            .await
-            .map_err(|error| {
-                ProxyConnectionError::Upstream(
-                    error.context("Failed to send proxied packet upstream"),
-                )
-            })?;
+        let upstream_packet = match rewrite_session_id(downstream_packet, upstream_session_id) {
+            Ok(packet) => packet,
+            Err(error) => {
+                return Err(ProxyConnectionError::Downstream(error));
+            }
+        };
 
-        let upstream_reply = read_upstream_packet(upstream_session, timeout).await?;
+        if let Err(error) = upstream_session.send_packet(upstream_packet).await {
+            return Err(ProxyConnectionError::Upstream(
+                error.context("Failed to send proxied packet upstream"),
+            ));
+        }
+
+        let upstream_reply = match read_upstream_packet(upstream_session, timeout).await {
+            Ok(packet) => packet,
+            Err(error) => return Err(error),
+        };
+
         let action = reply_action(&upstream_reply);
-        let downstream_reply = rewrite_session_id(upstream_reply, downstream_session_id)
-            .map_err(ProxyConnectionError::Upstream)?;
-        write_downstream_packet(writer, stream, downstream_reply).await?;
+        let downstream_reply = match rewrite_session_id(upstream_reply, downstream_session_id) {
+            Ok(packet) => packet,
+            Err(error) => return Err(ProxyConnectionError::Upstream(error)),
+        };
+        write_downstream_packet(writer, stream, downstream_reply, downstream_reply_obfuscation)
+            .await?;
 
         match action {
             ReplyAction::Continue => {}
@@ -330,6 +349,12 @@ mod tests {
         }
     }
 
+    fn test_server_with_secret(secret: &str) -> TacacsPlusServer {
+        let mut server = test_server();
+        server.shared_secret = Some(secret.to_owned());
+        server
+    }
+
     #[tokio::test]
     async fn proxy_connection_maps_session_id_and_preserves_body() {
         let downstream_session_id = 0x1111_2222;
@@ -372,6 +397,95 @@ mod tests {
 
         let downstream_reply = read_packet(&mut client_stream).await;
         assert_eq!(downstream_reply.header().session_id, downstream_session_id);
+        assert_eq!(downstream_reply.body(), &reply_body);
+    }
+
+    #[tokio::test]
+    async fn proxy_connection_preserves_unobfuscated_downstream_reply() {
+        let downstream_session_id = 0x1111_2222;
+        let upstream_session_id = 0x3333_4444;
+        let secret = "proxy-secret";
+        let request = test_packet(
+            TacacsType::TacPlusAccounting,
+            downstream_session_id,
+            b"request-body".to_vec(),
+        );
+        let reply_body = accounting_reply_body(TacacsAccountingStatus::TacPlusAcctStatusSuccess);
+        let upstream_reply =
+            test_packet(TacacsType::TacPlusAccounting, upstream_session_id, reply_body.clone());
+        let fake_session = FakeProxySession::new(upstream_session_id, vec![upstream_reply]);
+        let (proxy_stream, mut client_stream) = tokio::io::duplex(4096);
+
+        write_packet(&mut client_stream, &request).await;
+
+        proxy_connection_with_session(
+            proxy_stream,
+            &test_server_with_secret(secret),
+            Duration::from_secs(1),
+            Some(secret.as_bytes().to_vec()),
+            &fake_session,
+        )
+        .await
+        .expect("proxy connection should complete");
+
+        let downstream_reply = read_packet(&mut client_stream).await;
+        assert!(downstream_reply
+            .header()
+            .flags
+            .contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG));
+        assert_eq!(downstream_reply.header().session_id, downstream_session_id);
+        assert_eq!(downstream_reply.body(), &reply_body);
+    }
+
+    #[tokio::test]
+    async fn proxy_connection_preserves_obfuscated_downstream_reply() {
+        let downstream_session_id = 0x1111_2222;
+        let upstream_session_id = 0x3333_4444;
+        let secret = "proxy-secret";
+        let request_body = b"request-body".to_vec();
+        let request =
+            test_packet(TacacsType::TacPlusAccounting, downstream_session_id, request_body.clone())
+                .to_obfuscated(secret.as_bytes());
+        let reply_body = accounting_reply_body(TacacsAccountingStatus::TacPlusAcctStatusSuccess);
+        let upstream_reply =
+            test_packet(TacacsType::TacPlusAccounting, upstream_session_id, reply_body.clone());
+        let fake_session = FakeProxySession::new(upstream_session_id, vec![upstream_reply]);
+        let (proxy_stream, mut client_stream) = tokio::io::duplex(4096);
+
+        write_packet(&mut client_stream, &request).await;
+
+        proxy_connection_with_session(
+            proxy_stream,
+            &test_server_with_secret(secret),
+            Duration::from_secs(1),
+            Some(secret.as_bytes().to_vec()),
+            &fake_session,
+        )
+        .await
+        .expect("proxy connection should complete");
+
+        let (received_len, received_session_id, received_flags, received_body) = {
+            let received_packets = fake_session.received_packets.lock().await;
+            (
+                received_packets.len(),
+                received_packets[0].header().session_id,
+                received_packets[0].header().flags,
+                received_packets[0].body().clone(),
+            )
+        };
+        assert_eq!(received_len, 1);
+        assert_eq!(received_session_id, upstream_session_id);
+        assert!(received_flags.contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG));
+        assert_eq!(received_body, request_body);
+
+        let raw_downstream_reply = read_packet(&mut client_stream).await;
+        assert!(!raw_downstream_reply
+            .header()
+            .flags
+            .contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG));
+        assert_eq!(raw_downstream_reply.header().session_id, downstream_session_id);
+
+        let downstream_reply = raw_downstream_reply.to_deobfuscated(secret.as_bytes());
         assert_eq!(downstream_reply.body(), &reply_body);
     }
 

--- a/libraries/tacacsrs_agent/src/services/tacacs_proxy/upstream_bridge/packet_io.rs
+++ b/libraries/tacacsrs_agent/src/services/tacacs_proxy/upstream_bridge/packet_io.rs
@@ -2,36 +2,44 @@
 
 use std::time::Duration;
 
-use anyhow::bail;
-use tacacsrs_config::TacacsPlusServer;
+use anyhow::{Context, bail};
 use tacacsrs_flow_abstractions::client_session_flow_io::ClientSessionFlowIoTrait;
+use tacacsrs_messages::constants::{TACACS_HEADER_LENGTH, TACACS_MAX_BODY_LENGTH};
 use tacacsrs_messages::enumerations::TacacsFlags;
+use tacacsrs_messages::header::Header;
 use tacacsrs_messages::packet::{Packet, PacketTrait};
-use tacacsrs_networking::{
-    PacketReadResult, PacketReader, PacketReaderTrait, PacketWriteResult, PacketWriter,
-    PacketWriterTrait,
-};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tacacsrs_networking::{PacketWriteResult, PacketWriter, PacketWriterTrait};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 
 use super::error::ProxyConnectionError;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DownstreamObfuscation {
+    Unobfuscated,
+    Obfuscated,
+}
+
+pub(super) struct DownstreamPacket {
+    pub(super) packet: Packet,
+    pub(super) reply_obfuscation: DownstreamObfuscation,
+}
+
 pub(super) async fn read_downstream_packet<Stream>(
-    reader: &PacketReader,
     stream: &mut Stream,
     timeout: Duration,
-) -> Result<Packet, ProxyConnectionError>
+    obfuscation_key: Option<&[u8]>,
+) -> Result<DownstreamPacket, ProxyConnectionError>
 where
     Stream: AsyncRead + Unpin + Send,
 {
-    let result = tokio::time::timeout(timeout, reader.read_packet(stream))
+    tokio::time::timeout(timeout, read_downstream_packet_inner(stream, obfuscation_key))
         .await
         .map_err(|_| {
             ProxyConnectionError::Downstream(anyhow::anyhow!(
                 "Timed out waiting for downstream TACACS+ packet after {timeout:?}"
             ))
-        })?;
-
-    packet_read_result_to_result(result).map_err(ProxyConnectionError::Downstream)
+        })?
+        .map_err(ProxyConnectionError::Downstream)
 }
 
 pub(super) async fn read_upstream_packet<Session>(
@@ -59,11 +67,19 @@ pub(super) async fn write_downstream_packet<Stream>(
     writer: &PacketWriter,
     stream: &mut Stream,
     packet: Packet,
+    obfuscation: DownstreamObfuscation,
 ) -> Result<(), ProxyConnectionError>
 where
     Stream: AsyncWrite + Unpin + Send,
 {
-    match writer.write_packet(stream, packet).await {
+    let result = match obfuscation {
+        DownstreamObfuscation::Obfuscated => writer.write_packet(stream, packet).await,
+        DownstreamObfuscation::Unobfuscated => {
+            PacketWriter::new(None).write_packet(stream, packet).await
+        }
+    };
+
+    match result {
         PacketWriteResult::Success => Ok(()),
         PacketWriteResult::WriteError(error) => Err(ProxyConnectionError::Downstream(
             anyhow::Error::new(error).context("Failed to write TACACS+ proxy reply downstream"),
@@ -71,46 +87,70 @@ where
     }
 }
 
-pub(super) fn validate_downstream_obfuscation(
-    packet: &Packet,
-    server: &TacacsPlusServer,
-) -> Result<(), ProxyConnectionError> {
-    if server.shared_secret.is_some()
-        || packet
-            .header()
-            .flags
-            .contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG)
+async fn read_downstream_packet_inner<Stream>(
+    stream: &mut Stream,
+    obfuscation_key: Option<&[u8]>,
+) -> anyhow::Result<DownstreamPacket>
+where
+    Stream: AsyncRead + Unpin + Send,
+{
+    let mut header_buffer = [0_u8; TACACS_HEADER_LENGTH];
+    stream
+        .read_exact(&mut header_buffer)
+        .await
+        .context("Failed to read TACACS+ proxy header")?;
+
+    let header =
+        Header::from_bytes(&header_buffer).context("Failed to parse TACACS+ proxy header")?;
+    let session_id = header.session_id;
+    if header.length > TACACS_MAX_BODY_LENGTH {
+        bail!(
+            "TACACS+ proxy packet for session {session_id:#x} declared body length {}, exceeding maximum {}",
+            header.length,
+            TACACS_MAX_BODY_LENGTH,
+        );
+    }
+
+    let reply_obfuscation = if header
+        .flags
+        .contains(TacacsFlags::TAC_PLUS_UNENCRYPTED_FLAG)
     {
-        return Ok(());
-    }
+        DownstreamObfuscation::Unobfuscated
+    } else {
+        DownstreamObfuscation::Obfuscated
+    };
 
-    Err(ProxyConnectionError::Downstream(anyhow::anyhow!(
-        "Downstream TACACS+ packet for session {:#x} is obfuscated, but selected upstream server {} has no shared secret",
+    let mut body_buffer = vec![0_u8; header.length as usize];
+    stream.read_exact(&mut body_buffer).await.with_context(|| {
+        format!("Failed to read TACACS+ proxy body for session {session_id:#x}")
+    })?;
+
+    let mut packet = Packet::new(header, body_buffer).with_context(|| {
+        format!("Failed to create TACACS+ proxy packet for session {session_id:#x}")
+    })?;
+
+    log::debug!(
+        "Read TACACS+ proxy downstream packet: session_id={:#x}, seq_no={}, type={}, flags={:?}, body_length={}, obfuscated={}",
         packet.header().session_id,
-        server.name,
-    )))
-}
+        packet.header().seq_no,
+        packet.header().tacacs_type,
+        packet.header().flags,
+        packet.body().len(),
+        reply_obfuscation == DownstreamObfuscation::Obfuscated,
+    );
 
-fn packet_read_result_to_result(result: PacketReadResult) -> anyhow::Result<Packet> {
-    match result {
-        PacketReadResult::Success(packet) => Ok(packet),
-        PacketReadResult::HeaderReadError(error) => {
-            Err(anyhow::Error::new(error).context("Failed to read TACACS+ proxy header"))
+    if reply_obfuscation == DownstreamObfuscation::Obfuscated {
+        if let Some(key) = obfuscation_key {
+            log::debug!(
+                "Deobfuscating TACACS+ proxy downstream packet body for session {:#x}",
+                packet.header().session_id,
+            );
+            packet = packet.to_deobfuscated(key);
         }
-        PacketReadResult::HeaderParseError(error) => {
-            Err(error.context("Failed to parse TACACS+ proxy header"))
-        }
-        PacketReadResult::BodyLengthExceeded {
-            session_id,
-            body_length,
-            max_length,
-        } => bail!(
-            "TACACS+ proxy packet for session {session_id:#x} declared body length {body_length}, exceeding maximum {max_length}"
-        ),
-        PacketReadResult::BodyReadError { session_id, error } => Err(anyhow::Error::new(error)
-            .context(format!("Failed to read TACACS+ proxy body for session {session_id:#x}"))),
-        PacketReadResult::PacketCreateError { session_id, error } => Err(error.context(format!(
-            "Failed to create TACACS+ proxy packet for session {session_id:#x}"
-        ))),
     }
+
+    Ok(DownstreamPacket {
+        packet,
+        reply_obfuscation,
+    })
 }

--- a/libraries/tacacsrs_config/src/builders.rs
+++ b/libraries/tacacsrs_config/src/builders.rs
@@ -130,6 +130,13 @@ impl TacacsPlusServerBuilder {
         self
     }
 
+    /// Enables or disables TACACS+ single-connection negotiation for this server.
+    #[must_use]
+    pub fn with_single_connection(mut self, single_connection: bool) -> Self {
+        self.server.single_connection = single_connection;
+        self
+    }
+
     /// Selects obfuscation mode using the supplied shared secret.
     ///
     /// This clears any previously configured TLS identity fields. To add a


### PR DESCRIPTION
This pull request introduces a new `--dedicated` CLI flag to the `tacacsrs-agentd` executable, allowing users to choose between dedicated upstream connections per request or the default single-connection mode. Additionally, it refactors the TACACS+ proxy connection logic for improved error handling and obfuscation handling, and adds comprehensive tests for these new behaviors.

**Major changes include:**

### CLI and Connection Mode Enhancements

- Added a `--dedicated` command-line flag to `tacacsrs-agentd`, enabling a dedicated upstream connection per request instead of the default single-connection mode. The flag is mutually exclusive with `--sonic` and requires `--server-addr`. All relevant builder and initialization logic has been updated to support this new flag. [[1]](diffhunk://#diff-3344c95372aa559c80b6b8aa8adcd754b6d5b4bbd573352f9a60f27cbcdf208aR59) [[2]](diffhunk://#diff-3344c95372aa559c80b6b8aa8adcd754b6d5b4bbd573352f9a60f27cbcdf208aR124-R127) [[3]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L157-R157) [[4]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L189-R193) [[5]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L239-R249) [[6]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R259-R265)

- Added tests to verify that the `--dedicated` flag correctly toggles the single connection negotiation behavior.

### TACACS+ Proxy Logic Refactoring

- Refactored error handling in the proxy connection logic to use more idiomatic Rust patterns, improving clarity and robustness when binding servers and creating sessions. [[1]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L49-R65) [[2]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L89-R98) [[3]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L154-R188)

- Reworked downstream packet reading and obfuscation handling: replaced the use of a `PacketReader` with a new approach that tracks obfuscation state, and updated the proxy logic to preserve or apply obfuscation as needed. [[1]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L111-R116) [[2]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L125) [[3]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L137-R148) [[4]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2L154-R188) [[5]](diffhunk://#diff-919f8e88982e5516ab50317d594206b914a7680b1add950a0bbf19f56d16d7a4L5-R42)

### Testing Improvements

- Added comprehensive tests to verify that the proxy connection correctly preserves unobfuscated and obfuscated downstream replies, and that session IDs and packet bodies are handled as expected. [[1]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2R352-R357) [[2]](diffhunk://#diff-97d05dc2232a34602a473263e2fc53ae2f13cfb18364308e3dd91aa6d82fdea2R403-R491)

These changes collectively improve the flexibility, reliability, and correctness of TACACS+ proxying and connection management in the agent.lds CLI-specified upstream servers with TACACS+ single-connection negotiation enabled. This matches the preferred high-throughput behavior and aligns with tacon, where dedicated mode is an explicit opt-out.