### PR TITLE
feat(cli-datastore): introduce tacacsrs-cli-datastore library for CLI and file-backed TACACS+ configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1041,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1113,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1204,6 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1222,6 +1272,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1810,6 +1887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2159,7 @@ dependencies = [
  "rustls-pki-types",
  "tacacsrs-agent",
  "tacacsrs-agent-client",
+ "tacacsrs-cli-datastore",
  "tacacsrs-config",
  "tacacsrs-datastore",
  "tacacsrs-networking",
@@ -2088,6 +2175,24 @@ dependencies = [
  "libc",
  "tacacsrs-agent-client",
  "tokio",
+]
+
+[[package]]
+name = "tacacsrs-cli-datastore"
+version = "0.0.0-dev"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "futures-core",
+ "futures-util",
+ "log",
+ "notify",
+ "rustls-pki-types",
+ "tacacsrs-config",
+ "tacacsrs-datastore",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2194,7 +2299,6 @@ name = "tacon"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
  "clap",
  "clap_mangen",
  "env_logger",
@@ -2204,6 +2308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tacacsrs-agent-client",
+ "tacacsrs-cli-datastore",
  "tacacsrs-config",
  "tacacsrs-flows",
  "tacacsrs-messages",
@@ -2581,6 +2686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,6 +2729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,7 +2749,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2643,14 +2776,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2660,10 +2810,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2672,10 +2834,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2684,10 +2858,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2696,10 +2882,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "libraries/tacacsrs_agent",
     "libraries/tacacsrs_config",
     "libraries/tacacsrs_datastore",
+    "libraries/tacacsrs_cli_datastore",
     "libraries/tacacsrs_sonic",
     "libraries/tacacsrs_bash_plugin",
     "executables/tacon",

--- a/executables/tacacsrs_agentd/Cargo.toml
+++ b/executables/tacacsrs_agentd/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 rustls-pki-types = "1.14.1"
 tacacsrs-agent-client = { path = "../../libraries/tacacsrs_agent_client" }
 tacacsrs-agent = { path = "../../libraries/tacacsrs_agent" }
+tacacsrs-cli-datastore = { path = "../../libraries/tacacsrs_cli_datastore" }
 tacacsrs-config = { path = "../../libraries/tacacsrs_config" }
 tacacsrs-datastore = { path = "../../libraries/tacacsrs_datastore" }
 tacacsrs-networking = { path = "../../libraries/tacacsrs_networking" }
@@ -25,7 +26,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 [features]
 default = []
 console = ["console-subscriber"]
-psk = ["tacacsrs-agent/psk"]
+psk = ["tacacsrs-agent/psk", "tacacsrs-cli-datastore/psk"]
 
 [build-dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/executables/tacacsrs_agentd/src/main.rs
+++ b/executables/tacacsrs_agentd/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::doc_markdown)]
 
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -7,14 +8,16 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::Parser;
 use futures_util::StreamExt;
-use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
 use tacacsrs_agent::{EnabledServices, ServiceConfig, TacacsClientService};
 use tacacsrs_agent_client::IpcEndpoint;
-use tacacsrs_config::{
-    TacacsPlus, TacacsPlusBuilder, TacacsPlusServerBuilder, TacacsPlusServerExt,
-    TacacsPlusServerType, crypto_types::PrivateKeyFormat,
+use tacacsrs_cli_datastore::{
+    CliConfigSource, CliDatastoreInput, CliFileDatastore, CliSecurity, CliSecurityInputs,
+    CliServerInput,
 };
-use tacacsrs_datastore::{ConfigChange, ConfigDatastore, StaticDatastore};
+#[cfg(feature = "psk")]
+use tacacsrs_cli_datastore::{CliPskInputs, PskKeyExchangeMode, PskKeyMaterial};
+use tacacsrs_config::TacacsPlusServerExt;
+use tacacsrs_datastore::{ConfigChange, ConfigDatastore};
 use tacacsrs_sonic::{SonicConfigDb, SonicConnection, DEFAULT_REDIS_URL};
 
 mod cli;
@@ -28,80 +31,6 @@ use crate::systemd_notify::SystemdNotifier;
 #[cfg(unix)]
 fn parse_socket_mode(mode: &str) -> anyhow::Result<u32> {
     u32::from_str_radix(mode, 8).with_context(|| format!("Invalid socket mode: {mode}"))
-}
-
-fn data_contains_pem_header(data: &[u8]) -> bool {
-    const PEM_HEADER: &[u8] = b"-----BEGIN";
-
-    data.windows(PEM_HEADER.len())
-        .any(|window| window == PEM_HEADER)
-}
-
-fn normalize_cli_certificate_data(data: &[u8]) -> anyhow::Result<Vec<u8>> {
-    if data.is_empty() {
-        anyhow::bail!("client certificate data is empty");
-    }
-
-    if !data_contains_pem_header(data) {
-        return Ok(data.to_vec());
-    }
-
-    let certificates = CertificateDer::pem_slice_iter(data)
-        .collect::<Result<Vec<_>, _>>()
-        .context("failed to parse PEM client certificate")?;
-
-    if certificates.len() != 1 {
-        anyhow::bail!("client certificate file must contain exactly one PEM certificate");
-    }
-
-    Ok(certificates[0].as_ref().to_vec())
-}
-
-fn normalize_cli_private_key_data(data: &[u8]) -> anyhow::Result<(Vec<u8>, PrivateKeyFormat)> {
-    if data.is_empty() {
-        anyhow::bail!("client private key data is empty");
-    }
-
-    let private_key = if data_contains_pem_header(data) {
-        PrivateKeyDer::from_pem_slice(data).context("failed to parse PEM client private key")?
-    } else {
-        PrivateKeyDer::try_from(data).map_err(|_| {
-            anyhow::anyhow!(
-                "unsupported DER client private key format; expected PKCS#1, SEC1, or PKCS#8"
-            )
-        })?
-    };
-
-    let private_key_format = match &private_key {
-        PrivateKeyDer::Pkcs1(_) => PrivateKeyFormat::RsaPrivateKeyFormat,
-        PrivateKeyDer::Sec1(_) => PrivateKeyFormat::EcPrivateKeyFormat,
-        PrivateKeyDer::Pkcs8(_) => PrivateKeyFormat::OneAsymmetricKeyFormat,
-        _ => anyhow::bail!("unsupported client private key format"),
-    };
-
-    Ok((private_key.secret_der().to_vec(), private_key_format))
-}
-
-fn parse_host_port(addr: &str, default_port: u16) -> (String, u16) {
-    if let Some(rest) = addr.strip_prefix('[') {
-        if let Some((host, after_bracket)) = rest.split_once(']') {
-            let port = after_bracket
-                .strip_prefix(':')
-                .and_then(|p| p.parse::<u16>().ok())
-                .unwrap_or(default_port);
-            return (host.to_owned(), port);
-        }
-    }
-
-    if addr.matches(':').count() == 1 {
-        if let Some((host, port_str)) = addr.rsplit_once(':') {
-            if let Ok(port) = port_str.parse::<u16>() {
-                return (host.to_owned(), port);
-            }
-        }
-    }
-
-    (addr.to_owned(), default_port)
 }
 
 /// Initializes the logger based on verbosity level.
@@ -133,138 +62,6 @@ fn init_logger(verbose: u8) {
     }
 }
 
-/// Build the TACACS+ root configuration from CLI flags (legacy path, without a config file).
-fn tacacs_plus_from_cli(cli: &Cli) -> anyhow::Result<TacacsPlus> {
-    let timeout = u16::try_from(cli.connect_timeout_seconds).unwrap_or(u16::MAX);
-
-    let server_builders: Vec<TacacsPlusServerBuilder> = if cli.use_tls {
-        #[cfg(feature = "psk")]
-        if let (Some(psk_identity), Some(psk_key)) =
-            (cli.psk_identity.as_ref(), cli.psk_key.as_ref())
-        {
-            if matches!(cli.psk_key_exchange, Some(PskKeyExchange::PskOnly))
-                && !cli.psk_key_exchange_groups.is_empty()
-            {
-                anyhow::bail!(
-                    "--psk-key-exchange psk-only cannot be combined with --psk-key-exchange-groups; remove the groups or use --psk-key-exchange psk-dhe"
-                );
-            }
-
-            cli.server_addresses
-                .iter()
-                .enumerate()
-                .map(|(i, addr)| {
-                    let builder = base_server_builder_from_address(addr, i, timeout, cli.dedicated);
-                    match cli.psk_key_exchange {
-                        Some(PskKeyExchange::PskOnly) => builder.with_tls13_epsk_psk_only(
-                            psk_identity.clone(),
-                            psk_key.as_bytes().to_vec(),
-                        ),
-                        Some(PskKeyExchange::PskDhe) | None
-                            if !cli.psk_key_exchange_groups.is_empty() =>
-                        {
-                            builder.with_tls13_epsk_with_psk_dhe_groups(
-                                psk_identity.clone(),
-                                psk_key.as_bytes().to_vec(),
-                                cli.psk_key_exchange_groups.clone(),
-                            )
-                        }
-                        Some(PskKeyExchange::PskDhe) | None => builder
-                            .with_tls13_epsk(psk_identity.clone(), psk_key.as_bytes().to_vec()),
-                    }
-                })
-                .collect()
-        } else {
-            tls_cert_server_builders_from_cli(cli, timeout)?
-        }
-        #[cfg(not(feature = "psk"))]
-        {
-            tls_cert_server_builders_from_cli(cli, timeout)?
-        }
-    } else {
-        cli.server_addresses
-            .iter()
-            .enumerate()
-            .map(|(i, addr)| match cli.shared_secret.clone() {
-                Some(shared_secret) => {
-                    base_server_builder_from_address(addr, i, timeout, cli.dedicated)
-                        .with_shared_secret(shared_secret)
-                }
-                None => base_server_builder_from_address(addr, i, timeout, cli.dedicated),
-            })
-            .collect()
-    };
-
-    server_builders
-        .into_iter()
-        .fold(TacacsPlusBuilder::new(), TacacsPlusBuilder::with_server_builder)
-        .build()
-}
-
-/// Build TLS certificate-based server builders from CLI flags.
-fn tls_cert_server_builders_from_cli(
-    cli: &Cli,
-    timeout: u16,
-) -> anyhow::Result<Vec<TacacsPlusServerBuilder>> {
-    let client_cert_der = cli
-        .client_certificate
-        .as_ref()
-        .map(|path| {
-            let cert_data = std::fs::read(path)
-                .with_context(|| format!("Failed to read client certificate: {path}"))?;
-            normalize_cli_certificate_data(&cert_data)
-                .with_context(|| format!("Failed to parse client certificate: {path}"))
-        })
-        .transpose()?;
-    let client_key = cli
-        .client_key
-        .as_ref()
-        .map(|path| {
-            let key_data = std::fs::read(path)
-                .with_context(|| format!("Failed to read client key: {path}"))?;
-            normalize_cli_private_key_data(&key_data)
-                .with_context(|| format!("Failed to parse client key: {path}"))
-        })
-        .transpose()?;
-
-    let (client_key_der, client_key_format) = match client_key {
-        Some((der_bytes, private_key_format)) => (Some(der_bytes), Some(private_key_format)),
-        None => (None, None),
-    };
-
-    Ok(cli
-        .server_addresses
-        .iter()
-        .enumerate()
-        .map(|(i, addr)| {
-            if client_cert_der.is_some() || client_key_der.is_some() {
-                base_server_builder_from_address(addr, i, timeout, cli.dedicated)
-                    .with_tls_client_certificate_with_key_format(
-                        client_cert_der.clone(),
-                        client_key_der.clone(),
-                        client_key_format,
-                    )
-            } else {
-                base_server_builder_from_address(addr, i, timeout, cli.dedicated)
-                    .with_tls_server_authentication()
-            }
-        })
-        .collect())
-}
-
-fn base_server_builder_from_address(
-    addr: &str,
-    index: usize,
-    timeout: u16,
-    dedicated: bool,
-) -> TacacsPlusServerBuilder {
-    let (host, port) = parse_host_port(addr, 49);
-
-    TacacsPlusServerBuilder::new(format!("server-{index}"), TacacsPlusServerType::all(), host, port)
-        .with_timeout(timeout)
-        .with_single_connection(!dedicated)
-}
-
 fn enabled_services_from_cli(cli: &Cli) -> EnabledServices {
     match cli.service_mode.unwrap_or_else(|| {
         if cli.proxy_endpoint.is_some() {
@@ -279,17 +76,65 @@ fn enabled_services_from_cli(cli: &Cli) -> EnabledServices {
     }
 }
 
-fn tacacs_plus_from_config(path: &std::path::Path) -> anyhow::Result<TacacsPlus> {
-    tacacsrs_config::parse_yang_json_file(path)
-        .with_context(|| format!("Failed to load config from {}", path.display()))
+fn cli_datastore_input_from_cli(cli: &Cli) -> CliDatastoreInput {
+    let timeout = u16::try_from(cli.connect_timeout_seconds).unwrap_or(u16::MAX);
+    let servers = cli
+        .server_addresses
+        .iter()
+        .enumerate()
+        .map(|(index, address)| {
+            CliServerInput::new(format!("server-{index}"), address.clone())
+                .with_timeout_seconds(timeout)
+                .with_single_connection(!cli.dedicated)
+        })
+        .collect();
+
+    CliDatastoreInput::new(
+        CliConfigSource::Inline {
+            servers,
+            security: cli_security_from_cli(cli),
+        },
+        "cli",
+    )
+}
+
+fn cli_security_from_cli(cli: &Cli) -> CliSecurity {
+    CliSecurity::from_cli_inputs(CliSecurityInputs {
+        use_tls: cli.use_tls,
+        shared_secret: cli.shared_secret.clone(),
+        client_certificate: cli.client_certificate.clone().map(PathBuf::from),
+        client_key: cli.client_key.clone().map(PathBuf::from),
+        #[cfg(feature = "psk")]
+        psk: cli_psk_inputs(cli),
+    })
+}
+
+#[cfg(feature = "psk")]
+fn cli_psk_inputs(cli: &Cli) -> Option<CliPskInputs> {
+    let identity = cli.psk_identity.as_ref()?;
+    let key = cli.psk_key.as_ref()?;
+    Some(CliPskInputs {
+        identity: identity.clone(),
+        // agentd accepts the PSK as raw bytes on the command line.
+        key: PskKeyMaterial::Raw(key.as_bytes().to_vec()),
+        exchange: match cli.psk_key_exchange {
+            Some(PskKeyExchange::PskOnly) => PskKeyExchangeMode::PskOnly,
+            Some(PskKeyExchange::PskDhe) | None => PskKeyExchangeMode::PskDhe,
+        },
+        groups: cli.psk_key_exchange_groups.clone(),
+    })
 }
 
 /// Construct the [`ConfigDatastore`] selected by the operator on the CLI.
 ///
-/// File and CLI flag inputs are wrapped in a [`StaticDatastore`] so the rest
-/// of the daemon code path is identical regardless of where the config came
-/// from. `--sonic` selects the SONiC ConfigDB-backed datastore.
-fn build_datastore(cli: &Cli) -> anyhow::Result<Arc<dyn ConfigDatastore>> {
+/// File and CLI flag inputs are wrapped in a file-backed CLI datastore so YANG
+/// config and CLI-provided TLS certificate/key files can trigger hot reloads.
+/// `--sonic` selects the SONiC ConfigDB-backed datastore.
+///
+/// Construction is infallible: every datastore validates its configuration
+/// lazily in [`ConfigDatastore::load`], so configuration errors surface when
+/// the daemon performs its initial load rather than here.
+fn build_datastore(cli: &Cli) -> Arc<dyn ConfigDatastore> {
     if cli.sonic {
         let mut settings = SonicConnection::default();
         if let Some(url) = cli.sonic_redis_url.clone() {
@@ -305,17 +150,20 @@ fn build_datastore(cli: &Cli) -> anyhow::Result<Arc<dyn ConfigDatastore>> {
             settings.url,
             settings.db_index,
         );
-        return Ok(Arc::new(SonicConfigDb::new(settings)));
+        return Arc::new(SonicConfigDb::new(settings));
     }
 
     if let Some(ref config_path) = cli.config {
         log::info!("Loading YANG JSON configuration from {}", config_path.display());
-        let config = tacacs_plus_from_config(config_path)?;
-        return Ok(Arc::new(StaticDatastore::with_label(config, "file")));
+        return Arc::new(CliFileDatastore::new(CliDatastoreInput::new(
+            CliConfigSource::YangFile {
+                path: config_path.clone(),
+            },
+            "file",
+        )));
     }
 
-    let config = tacacs_plus_from_cli(cli)?;
-    Ok(Arc::new(StaticDatastore::with_label(config, "cli")))
+    Arc::new(CliFileDatastore::new(cli_datastore_input_from_cli(cli)))
 }
 
 async fn apply_config_change(
@@ -423,7 +271,7 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let datastore = build_datastore(&cli)?;
+    let datastore = build_datastore(&cli);
     let tacacs_plus = {
         let initial = datastore.load().await.with_context(|| {
             format!("Failed to load configuration from datastore '{}'", datastore.label())
@@ -479,10 +327,7 @@ mod tests {
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{
-        Cli, apply_config_change, enabled_services_from_cli, tacacs_plus_from_cli,
-        tacacs_plus_from_config,
-    };
+    use super::{Cli, apply_config_change, cli_datastore_input_from_cli, enabled_services_from_cli};
     use tacacsrs_agent::{EnabledServices, ServiceConfig, TacacsClientService};
     use tacacsrs_agent_client::IpcEndpoint;
     #[cfg(feature = "psk")]
@@ -490,7 +335,9 @@ mod tests {
     use tacacsrs_config::crypto_types::PrivateKeyFormat;
     use tacacsrs_config::{
         TacacsPlus, TacacsPlusBuilder, TacacsPlusServerBuilder, TacacsPlusServerType,
+        ValidationOptions,
     };
+    use tacacsrs_cli_datastore::{tacacs_plus_from_cli_input, tacacs_plus_from_file};
     use tacacsrs_datastore::{ConfigChange, ConfigDelta};
 
     fn sample_path(file_name: &str) -> PathBuf {
@@ -574,7 +421,8 @@ mod tests {
             }"#,
         );
 
-        let root = tacacs_plus_from_config(&path).expect("config file should load");
+        let root = tacacs_plus_from_file(&path, &ValidationOptions::default())
+            .expect("config file should load");
         fs::remove_file(&path).ok();
 
         assert_eq!(root.server.len(), 2);
@@ -593,7 +441,8 @@ mod tests {
             "secret1",
         ]);
 
-        let root = tacacs_plus_from_cli(&cli).expect("plain-text shared secret should load");
+        let root = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(&cli))
+            .expect("plain-text shared secret should load");
         assert_eq!(root.server[0].shared_secret.as_deref(), Some("secret1"));
     }
 
@@ -607,7 +456,8 @@ mod tests {
             "secret1",
         ]);
 
-        let root = tacacs_plus_from_cli(&cli).expect("CLI config should load");
+        let root = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(&cli))
+            .expect("CLI config should load");
         assert!(root.server[0].single_connection);
     }
 
@@ -622,7 +472,8 @@ mod tests {
             "--dedicated",
         ]);
 
-        let root = tacacs_plus_from_cli(&cli).expect("CLI config should load");
+        let root = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(&cli))
+            .expect("CLI config should load");
         assert!(!root.server[0].single_connection);
     }
 
@@ -708,7 +559,8 @@ mod tests {
             key_path.to_str().expect("path should be UTF-8"),
         ]);
 
-        let root = tacacs_plus_from_cli(&cli).expect("PEM client identity should load");
+        let root = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(&cli))
+            .expect("PEM client identity should load");
         let inline = root.server[0]
             .client_identity
             .as_ref()
@@ -723,7 +575,8 @@ mod tests {
 
     #[cfg(feature = "psk")]
     fn tls13_epsk_groups(cli: &Cli) -> Vec<PskDheKeSupportedGroup> {
-        let mut root = tacacs_plus_from_cli(cli).expect("PSK config should build");
+        let mut root = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(cli))
+            .expect("PSK config should build");
         root.server
             .remove(0)
             .client_identity
@@ -812,7 +665,8 @@ mod tests {
             "secp384r1",
         ]);
 
-        let error = tacacs_plus_from_cli(&cli).expect_err("PSK-only plus groups should fail");
+        let error = tacacs_plus_from_cli_input(&cli_datastore_input_from_cli(&cli))
+            .expect_err("PSK-only plus groups should fail");
         assert!(error.to_string().contains("--psk-key-exchange psk-only"));
         assert!(error.to_string().contains("--psk-key-exchange-groups"));
     }

--- a/executables/tacon/Cargo.toml
+++ b/executables/tacon/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-base64 = { version = "0.22", optional = true }
 clap = { version = "4.6.1", features = ["derive"] }
 env_logger = "0.11.10"
 futures = "0.3"
@@ -20,6 +19,7 @@ rustls-pki-types = "1.14.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tacacsrs-agent-client = { path = "../../libraries/tacacsrs_agent_client" }
+tacacsrs-cli-datastore = { path = "../../libraries/tacacsrs_cli_datastore" }
 tacacsrs-config = { path = "../../libraries/tacacsrs_config" }
 tacacsrs-messages = { path = "../../libraries/tacacsrs_messages" }
 tacacsrs-flows = { path = "../../libraries/tacacsrs_flows" }
@@ -28,7 +28,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 default = []
-psk = ["dep:base64", "tacacsrs-networking/psk"]
+psk = ["tacacsrs-cli-datastore/psk", "tacacsrs-networking/psk"]
 
 [build-dependencies]
 clap = { version = "4.6.1", features = ["derive"] }

--- a/executables/tacon/src/config.rs
+++ b/executables/tacon/src/config.rs
@@ -1,89 +1,20 @@
+use std::path::PathBuf;
+
 use anyhow::Context;
+use tacacsrs_cli_datastore::{
+    CliConfigSource, CliDatastoreInput, CliSecurity, CliSecurityInputs, CliServerInput,
+    tacacs_plus_from_cli_input, tacacs_plus_from_file as shared_tacacs_plus_from_file,
+};
 #[cfg(feature = "psk")]
-use base64::Engine as _;
-use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use tacacsrs_cli_datastore::{CliPskInputs, PskKeyExchangeMode, PskKeyMaterial};
 use tacacsrs_config::{
-    TacacsPlus, TacacsPlusBuilder, TacacsPlusServer, TacacsPlusServerBuilder, TacacsPlusServerExt,
-    TacacsPlusServerType, ValidationOptions, YangConfigRoot, crypto_types::PrivateKeyFormat,
+    TacacsPlus, TacacsPlusServer, TacacsPlusServerExt, TacacsPlusServerType, ValidationOptions,
+    YangConfigRoot,
 };
 
 use crate::cli::{Cli, Command};
 #[cfg(feature = "psk")]
 use crate::cli::PskKeyExchange;
-
-fn data_contains_pem_header(data: &[u8]) -> bool {
-    const PEM_HEADER: &[u8] = b"-----BEGIN";
-
-    data.windows(PEM_HEADER.len())
-        .any(|window| window == PEM_HEADER)
-}
-
-fn normalize_cli_certificate_data(data: &[u8]) -> anyhow::Result<Vec<u8>> {
-    if data.is_empty() {
-        anyhow::bail!("client certificate data is empty");
-    }
-
-    if !data_contains_pem_header(data) {
-        return Ok(data.to_vec());
-    }
-
-    let certificates = CertificateDer::pem_slice_iter(data)
-        .collect::<Result<Vec<_>, _>>()
-        .context("failed to parse PEM client certificate")?;
-
-    if certificates.len() != 1 {
-        anyhow::bail!("client certificate file must contain exactly one PEM certificate");
-    }
-
-    Ok(certificates[0].as_ref().to_vec())
-}
-
-fn normalize_cli_private_key_data(data: &[u8]) -> anyhow::Result<(Vec<u8>, PrivateKeyFormat)> {
-    if data.is_empty() {
-        anyhow::bail!("client private key data is empty");
-    }
-
-    let private_key = if data_contains_pem_header(data) {
-        PrivateKeyDer::from_pem_slice(data).context("failed to parse PEM client private key")?
-    } else {
-        PrivateKeyDer::try_from(data).map_err(|_| {
-            anyhow::anyhow!(
-                "unsupported DER client private key format; expected PKCS#1, SEC1, or PKCS#8"
-            )
-        })?
-    };
-
-    let private_key_format = match &private_key {
-        PrivateKeyDer::Pkcs1(_) => PrivateKeyFormat::RsaPrivateKeyFormat,
-        PrivateKeyDer::Sec1(_) => PrivateKeyFormat::EcPrivateKeyFormat,
-        PrivateKeyDer::Pkcs8(_) => PrivateKeyFormat::OneAsymmetricKeyFormat,
-        _ => anyhow::bail!("unsupported client private key format"),
-    };
-
-    Ok((private_key.secret_der().to_vec(), private_key_format))
-}
-
-fn parse_host_port(addr: &str, default_port: u16) -> (String, u16) {
-    if let Some(rest) = addr.strip_prefix('[') {
-        if let Some((host, after_bracket)) = rest.split_once(']') {
-            let port = after_bracket
-                .strip_prefix(':')
-                .and_then(|p| p.parse::<u16>().ok())
-                .unwrap_or(default_port);
-            return (host.to_owned(), port);
-        }
-    }
-
-    if addr.matches(':').count() == 1 {
-        if let Some((host, port_str)) = addr.rsplit_once(':') {
-            if let Ok(port) = port_str.parse::<u16>() {
-                return (host.to_owned(), port);
-            }
-        }
-    }
-
-    (addr.to_owned(), default_port)
-}
 
 /// Builds a single-server [`TacacsPlus`] root from CLI flags for direct-mode connections.
 ///
@@ -91,32 +22,26 @@ fn parse_host_port(addr: &str, default_port: u16) -> (String, u16) {
 ///
 /// Returns an error if `--server-addr` is not provided or the address cannot be parsed.
 pub fn tacacs_plus_from_cli(cli: &Cli) -> anyhow::Result<TacacsPlus> {
-    let options = validation_options_from_cli(cli);
-
     let server_addr = cli
         .server_addr
         .as_deref()
         .context("A TACACS+ server address is required for direct mode")?;
 
-    let (host, port) = parse_host_port(server_addr, 49);
-
-    let mut server = populate_security_from_cli(
-        cli,
-        TacacsPlusServerBuilder::new("cli", TacacsPlusServerType::all(), host, port)
-            .with_timeout(5),
-        &options,
-    )?;
-
+    let mut server = CliServerInput::new("cli", server_addr).with_single_connection(true);
     if let Some(tls_server_name) = cli.tls_server_name.as_ref() {
-        server.domain_name = Some(tls_server_name.clone());
-        server.sni_enabled = Some(true);
+        server = server.with_tls_server_name(tls_server_name.clone());
     }
 
-    server.single_connection = true;
+    let input = CliDatastoreInput::new(
+        CliConfigSource::Inline {
+            servers: vec![server],
+            security: cli_security_from_cli(cli),
+        },
+        "cli",
+    )
+    .with_validation_options(validation_options_from_cli(cli));
 
-    TacacsPlusBuilder::new()
-        .with_server(server)
-        .build_with_options(&options)
+    tacacs_plus_from_cli_input(&input)
 }
 
 fn validation_options_from_cli(cli: &Cli) -> ValidationOptions {
@@ -144,129 +69,31 @@ fn validation_options_from_cli(cli: &Cli) -> ValidationOptions {
         })
 }
 
-fn populate_security_from_cli(
-    cli: &Cli,
-    builder: TacacsPlusServerBuilder,
-    options: &ValidationOptions,
-) -> anyhow::Result<TacacsPlusServer> {
-    use tacacsrs_config::ValidationRelaxation;
-
-    if cli.use_tls {
+fn cli_security_from_cli(cli: &Cli) -> CliSecurity {
+    CliSecurity::from_cli_inputs(CliSecurityInputs {
+        use_tls: cli.use_tls,
+        shared_secret: cli.shared_secret.clone(),
+        client_certificate: cli.client_certificate.clone().map(PathBuf::from),
+        client_key: cli.client_key.clone().map(PathBuf::from),
         #[cfg(feature = "psk")]
-        if let (Some(psk_identity), Some(psk_key)) =
-            (cli.psk_identity.as_ref(), cli.psk_key.as_ref())
-        {
-            let psk_key = decode_cli_psk_key(psk_key)?;
-            let tls_builder = apply_psk_key_exchange(cli, builder, psk_identity.clone(), psk_key)?;
-
-            if options.allows(&ValidationRelaxation::AllowTlsWithSharedSecret) {
-                if let Some(ref secret) = cli.shared_secret {
-                    return Ok(tls_builder
-                        .with_shared_secret_alongside_tls(secret.clone())
-                        .build());
-                }
-            }
-            return Ok(tls_builder.build());
-        }
-
-        let client_cert_der = cli
-            .client_certificate
-            .as_ref()
-            .map(|path| {
-                let cert_data = std::fs::read(path)
-                    .with_context(|| format!("Failed to read client certificate: {path}"))?;
-                normalize_cli_certificate_data(&cert_data)
-                    .with_context(|| format!("Failed to parse client certificate: {path}"))
-            })
-            .transpose()?;
-        let client_key = cli
-            .client_key
-            .as_ref()
-            .map(|path| {
-                let key_data = std::fs::read(path)
-                    .with_context(|| format!("Failed to read client key: {path}"))?;
-                normalize_cli_private_key_data(&key_data)
-                    .with_context(|| format!("Failed to parse client key: {path}"))
-            })
-            .transpose()?;
-
-        let (client_key_der, client_key_format) = match client_key {
-            Some((der_bytes, private_key_format)) => (Some(der_bytes), Some(private_key_format)),
-            None => (None, None),
-        };
-
-        let tls_builder = if client_cert_der.is_some() || client_key_der.is_some() {
-            builder.with_tls_client_certificate_with_key_format(
-                client_cert_der,
-                client_key_der,
-                client_key_format,
-            )
-        } else {
-            builder.with_tls_server_authentication()
-        };
-
-        if options.allows(&ValidationRelaxation::AllowTlsWithSharedSecret) {
-            if let Some(ref secret) = cli.shared_secret {
-                return Ok(tls_builder
-                    .with_shared_secret_alongside_tls(secret.clone())
-                    .build());
-            }
-        }
-
-        Ok(tls_builder.build())
-    } else {
-        Ok(match cli.shared_secret.clone() {
-            Some(shared_secret) => builder.with_shared_secret(shared_secret).build(),
-            None => builder.build(),
-        })
-    }
-}
-
-#[cfg(feature = "psk")]
-fn decode_cli_psk_key(psk_key: &str) -> anyhow::Result<Vec<u8>> {
-    base64::engine::general_purpose::STANDARD
-        .decode(psk_key)
-        .context("--psk-key must be standard base64-encoded PSK bytes")
-}
-
-#[cfg(feature = "psk")]
-fn apply_psk_key_exchange(
-    cli: &Cli,
-    builder: TacacsPlusServerBuilder,
-    psk_identity: String,
-    psk_key: Vec<u8>,
-) -> anyhow::Result<TacacsPlusServerBuilder> {
-    if matches!(cli.psk_key_exchange, Some(PskKeyExchange::PskOnly))
-        && !cli.psk_key_exchange_groups.is_empty()
-    {
-        anyhow::bail!(
-            "--psk-key-exchange psk-only cannot be combined with --psk-key-exchange-groups; remove the groups or use --psk-key-exchange psk-dhe"
-        );
-    }
-
-    Ok(match cli.psk_key_exchange {
-        Some(PskKeyExchange::PskOnly) => builder.with_tls13_epsk_psk_only(psk_identity, psk_key),
-        Some(PskKeyExchange::PskDhe) | None if !cli.psk_key_exchange_groups.is_empty() => builder
-            .with_tls13_epsk_with_psk_dhe_groups(
-                psk_identity,
-                psk_key,
-                cli.psk_key_exchange_groups.clone(),
-            ),
-        Some(PskKeyExchange::PskDhe) | None => builder.with_tls13_epsk(psk_identity, psk_key),
+        psk: cli_psk_inputs(cli),
     })
 }
 
-/// Loads a [`TacacsPlus`] root from a YANG JSON string with the supplied validation options.
-///
-/// # Errors
-///
-/// Returns an error if the config cannot be parsed.
-pub fn tacacs_plus_from_str(
-    contents: &str,
-    options: &ValidationOptions,
-) -> anyhow::Result<TacacsPlus> {
-    tacacsrs_config::parse_yang_json_with_options(contents, options)
-        .context("Failed to load config from provided YANG JSON")
+#[cfg(feature = "psk")]
+fn cli_psk_inputs(cli: &Cli) -> Option<CliPskInputs> {
+    let identity = cli.psk_identity.as_ref()?;
+    let key = cli.psk_key.as_ref()?;
+    Some(CliPskInputs {
+        identity: identity.clone(),
+        // tacon accepts the PSK as a standard base64 string on the command line.
+        key: PskKeyMaterial::StandardBase64(key.clone()),
+        exchange: match cli.psk_key_exchange {
+            Some(PskKeyExchange::PskOnly) => PskKeyExchangeMode::PskOnly,
+            Some(PskKeyExchange::PskDhe) | None => PskKeyExchangeMode::PskDhe,
+        },
+        groups: cli.psk_key_exchange_groups.clone(),
+    })
 }
 
 /// Loads a [`TacacsPlus`] root from a YANG JSON config file with the supplied validation options.
@@ -278,11 +105,7 @@ pub fn tacacs_plus_from_file(
     path: &std::path::Path,
     options: &ValidationOptions,
 ) -> anyhow::Result<TacacsPlus> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read config from {}", path.display()))?;
-
-    tacacs_plus_from_str(&contents, options)
-        .with_context(|| format!("Failed to load config from {}", path.display()))
+    shared_tacacs_plus_from_file(path, options)
 }
 
 /// Resolves a [`TacacsPlus`] root configuration from either `--config` or CLI flags.
@@ -396,14 +219,12 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    use super::{
-        render_yang_config, select_first_server_for_type, tacacs_plus_from_cli,
-        tacacs_plus_from_str,
-    };
+    use super::{render_yang_config, select_first_server_for_type, tacacs_plus_from_cli};
     use crate::cli::Cli;
     #[cfg(feature = "psk")]
     use tacacsrs_config::PskDheKeSupportedGroup;
     use tacacsrs_config::{TacacsPlusServerType, ValidationOptions, crypto_types::PrivateKeyFormat};
+    use tacacsrs_cli_datastore::tacacs_plus_from_str;
 
     fn sample_path(file_name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/libraries/tacacsrs_cli_datastore/Cargo.toml
+++ b/libraries/tacacsrs_cli_datastore/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "tacacsrs-cli-datastore"
+description = "CLI and file-backed datastore for TACACS+ configuration inputs."
+version = "0.0.0-dev"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+base64 = { version = "0.22", optional = true }
+futures-core = "0.3"
+futures-util = "0.3"
+log = "0.4"
+notify = "8.2.0"
+rustls-pki-types = "1.14.1"
+tacacsrs-config = { path = "../tacacsrs_config" }
+tacacsrs-datastore = { path = "../tacacsrs_datastore" }
+tokio = { version = "1.52.3", features = ["macros", "rt", "sync", "time"] }
+tokio-stream = "0.1"
+
+[features]
+default = []
+psk = ["dep:base64"]
+
+[dev-dependencies]
+tokio = { version = "1.52.3", features = ["full"] }
+
+[lints]
+workspace = true

--- a/libraries/tacacsrs_cli_datastore/README.md
+++ b/libraries/tacacsrs_cli_datastore/README.md
@@ -1,0 +1,8 @@
+# tacacsrs-cli-datastore
+
+CLI and file-backed datastore support for TACACS+ configuration inputs.
+
+This crate adapts already-parsed command-line fields into validated
+`tacacsrs_config::TacacsPlus` snapshots. It also provides a file-watching
+`ConfigDatastore` for daemon workflows that need to reload when a YANG config
+file or CLI-provided TLS certificate/key file changes.

--- a/libraries/tacacsrs_cli_datastore/src/address.rs
+++ b/libraries/tacacsrs_cli_datastore/src/address.rs
@@ -1,0 +1,44 @@
+/// Parse a TACACS+ host/port string, returning `default_port` when no valid
+/// explicit port is present.
+#[must_use]
+pub fn parse_host_port(addr: &str, default_port: u16) -> (String, u16) {
+    if let Some(rest) = addr.strip_prefix('[') {
+        if let Some((host, after_bracket)) = rest.split_once(']') {
+            let port = after_bracket
+                .strip_prefix(':')
+                .and_then(|p| p.parse::<u16>().ok())
+                .unwrap_or(default_port);
+            return (host.to_owned(), port);
+        }
+    }
+
+    if addr.matches(':').count() == 1 {
+        if let Some((host, port_str)) = addr.rsplit_once(':') {
+            if let Ok(port) = port_str.parse::<u16>() {
+                return (host.to_owned(), port);
+            }
+        }
+    }
+
+    (addr.to_owned(), default_port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_host_port;
+
+    #[test]
+    fn parses_host_port() {
+        assert_eq!(parse_host_port("192.0.2.10:4949", 49), ("192.0.2.10".to_owned(), 4949));
+    }
+
+    #[test]
+    fn uses_default_port() {
+        assert_eq!(parse_host_port("192.0.2.10", 49), ("192.0.2.10".to_owned(), 49));
+    }
+
+    #[test]
+    fn parses_bracketed_ipv6() {
+        assert_eq!(parse_host_port("[2001:db8::1]:4949", 49), ("2001:db8::1".to_owned(), 4949));
+    }
+}

--- a/libraries/tacacsrs_cli_datastore/src/builder.rs
+++ b/libraries/tacacsrs_cli_datastore/src/builder.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+
+use anyhow::Context;
+use tacacsrs_config::{
+    TacacsPlus, TacacsPlusBuilder, TacacsPlusServer, TacacsPlusServerBuilder, ValidationOptions,
+};
+
+use crate::address::parse_host_port;
+use crate::files::{load_client_certificate, load_client_private_key};
+use crate::model::{
+    CertKeyIdentity, CliConfigSource, CliDatastoreInput, CliSecurity, CliSecurityMode,
+    CliServerInput,
+};
+#[cfg(feature = "psk")]
+use crate::model::{PskKeyExchangeMode, PskKeyMaterial};
+
+/// Loads a [`TacacsPlus`] root from a YANG JSON string with the supplied validation options.
+///
+/// # Errors
+///
+/// Returns an error if the config cannot be parsed or validated.
+pub fn tacacs_plus_from_str(
+    contents: &str,
+    options: &ValidationOptions,
+) -> anyhow::Result<TacacsPlus> {
+    tacacsrs_config::parse_yang_json_with_options(contents, options)
+        .context("Failed to load config from provided YANG JSON")
+}
+
+/// Loads a [`TacacsPlus`] root from a YANG JSON config file with the supplied validation options.
+///
+/// # Errors
+///
+/// Returns an error if the config file cannot be read, parsed, or validated.
+pub fn tacacs_plus_from_file(
+    path: &Path,
+    options: &ValidationOptions,
+) -> anyhow::Result<TacacsPlus> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config from {}", path.display()))?;
+
+    tacacs_plus_from_str(&contents, options)
+        .with_context(|| format!("Failed to load config from {}", path.display()))
+}
+
+/// Build a validated [`TacacsPlus`] root from parsed CLI/file inputs.
+///
+/// # Errors
+///
+/// Returns an error if referenced files cannot be read or if validation fails.
+pub fn tacacs_plus_from_cli_input(input: &CliDatastoreInput) -> anyhow::Result<TacacsPlus> {
+    match &input.source {
+        CliConfigSource::YangFile { path } => {
+            tacacs_plus_from_file(path, &input.validation_options)
+        }
+        CliConfigSource::Inline { servers, security } => {
+            inline_tacacs_plus_from_cli_input(servers, security, &input.validation_options)
+        }
+    }
+}
+
+fn inline_tacacs_plus_from_cli_input(
+    servers: &[CliServerInput],
+    security: &CliSecurity,
+    options: &ValidationOptions,
+) -> anyhow::Result<TacacsPlus> {
+    servers
+        .iter()
+        .map(|server| server_from_cli_input(server, security, options))
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .fold(TacacsPlusBuilder::new(), TacacsPlusBuilder::with_server)
+        .build_with_options(options)
+}
+
+fn server_from_cli_input(
+    input: &CliServerInput,
+    security: &CliSecurity,
+    options: &ValidationOptions,
+) -> anyhow::Result<TacacsPlusServer> {
+    let (host, port) = parse_host_port(&input.address, 49);
+    let builder = TacacsPlusServerBuilder::new(&input.name, input.server_type, host, port)
+        .with_timeout(input.timeout_seconds)
+        .with_single_connection(input.single_connection);
+
+    let shared_secret = security.shared_secret.as_ref();
+    let mut server = match &security.mode {
+        CliSecurityMode::PlainTcp => match shared_secret {
+            Some(shared_secret) => builder.with_shared_secret(shared_secret.clone()).build(),
+            None => builder.build(),
+        },
+        CliSecurityMode::TlsServerAuthentication => tls_builder_with_optional_shared_secret(
+            builder.with_tls_server_authentication(),
+            shared_secret,
+            options,
+        )
+        .build(),
+        CliSecurityMode::TlsClientCertificate { identity } => {
+            let tls_builder = tls_client_certificate_builder(builder, identity)?;
+            tls_builder_with_optional_shared_secret(tls_builder, shared_secret, options).build()
+        }
+        #[cfg(feature = "psk")]
+        CliSecurityMode::TlsPsk {
+            identity,
+            key,
+            exchange,
+            groups,
+        } => {
+            let tls_builder =
+                psk_builder(builder, identity.clone(), key.clone(), *exchange, groups)?;
+            tls_builder_with_optional_shared_secret(tls_builder, shared_secret, options).build()
+        }
+    };
+
+    if let Some(tls_server_name) = &input.tls_server_name {
+        server.domain_name = Some(tls_server_name.domain_name.clone());
+        server.sni_enabled = Some(tls_server_name.sni_enabled);
+    }
+
+    Ok(server)
+}
+
+fn tls_builder_with_optional_shared_secret(
+    builder: TacacsPlusServerBuilder,
+    shared_secret: Option<&String>,
+    options: &ValidationOptions,
+) -> TacacsPlusServerBuilder {
+    use tacacsrs_config::ValidationRelaxation;
+
+    if options.allows(&ValidationRelaxation::AllowTlsWithSharedSecret) {
+        if let Some(shared_secret) = shared_secret {
+            return builder.with_shared_secret_alongside_tls(shared_secret.clone());
+        }
+    }
+    builder
+}
+
+fn tls_client_certificate_builder(
+    builder: TacacsPlusServerBuilder,
+    identity: &CertKeyIdentity,
+) -> anyhow::Result<TacacsPlusServerBuilder> {
+    let client_cert_der = load_client_certificate(&identity.certificate_path)?;
+    let (client_key_der, client_key_format) = load_client_private_key(&identity.private_key_path)?;
+
+    Ok(builder.with_tls_client_certificate_with_key_format(
+        Some(client_cert_der),
+        Some(client_key_der),
+        Some(client_key_format),
+    ))
+}
+
+#[cfg(feature = "psk")]
+fn psk_builder(
+    builder: TacacsPlusServerBuilder,
+    identity: String,
+    key: PskKeyMaterial,
+    exchange: PskKeyExchangeMode,
+    groups: &[tacacsrs_config::PskDheKeSupportedGroup],
+) -> anyhow::Result<TacacsPlusServerBuilder> {
+    if exchange == PskKeyExchangeMode::PskOnly && !groups.is_empty() {
+        anyhow::bail!(
+            "--psk-key-exchange psk-only cannot be combined with --psk-key-exchange-groups; remove the groups or use --psk-key-exchange psk-dhe"
+        );
+    }
+
+    let key = key.into_bytes()?;
+    Ok(match exchange {
+        PskKeyExchangeMode::PskOnly => builder.with_tls13_epsk_psk_only(identity, key),
+        PskKeyExchangeMode::PskDhe if !groups.is_empty() => {
+            builder.with_tls13_epsk_with_psk_dhe_groups(identity, key, groups.to_vec())
+        }
+        PskKeyExchangeMode::PskDhe => builder.with_tls13_epsk(identity, key),
+    })
+}

--- a/libraries/tacacsrs_cli_datastore/src/datastore.rs
+++ b/libraries/tacacsrs_cli_datastore/src/datastore.rs
@@ -1,0 +1,257 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tacacsrs_config::TacacsPlus;
+use tacacsrs_datastore::{watch_to_change_stream, ConfigChangeStream, ConfigDatastore};
+use tokio::sync::{mpsc, watch};
+
+use crate::builder::tacacs_plus_from_cli_input;
+use crate::model::CliDatastoreInput;
+
+/// File-backed datastore for CLI-supplied TACACS+ configuration inputs.
+///
+/// The datastore rebuilds the effective [`TacacsPlus`] snapshot from the
+/// original CLI/file inputs on every relevant filesystem event. A successful
+/// rebuild is published to subscribers; failed reloads are logged and the
+/// previous active configuration remains in effect.
+#[derive(Debug, Clone)]
+pub struct CliFileDatastore {
+    input: CliDatastoreInput,
+}
+
+impl CliFileDatastore {
+    /// Create a new file-backed datastore from parsed CLI inputs.
+    #[must_use]
+    pub fn new(input: CliDatastoreInput) -> Self {
+        Self { input }
+    }
+
+    /// Parsed input model used to build each configuration snapshot.
+    #[must_use]
+    pub fn input(&self) -> &CliDatastoreInput {
+        &self.input
+    }
+}
+
+#[async_trait]
+impl ConfigDatastore for CliFileDatastore {
+    async fn load(&self) -> anyhow::Result<TacacsPlus> {
+        tacacs_plus_from_cli_input(&self.input)
+    }
+
+    async fn subscribe(&self) -> anyhow::Result<ConfigChangeStream> {
+        let watched_paths = self.input.watched_paths();
+        if watched_paths.is_empty() {
+            return Ok(Box::pin(tokio_stream::empty()));
+        }
+
+        let initial = self.load().await.ok().map(Arc::new);
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial);
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let watch_dirs = watch_directories(&watched_paths);
+        let mut watcher = RecommendedWatcher::new(
+            move |event| {
+                if event_tx.blocking_send(event).is_err() {
+                    log::debug!("CLI file datastore subscriber dropped; exiting watcher callback");
+                }
+            },
+            Config::default(),
+        )
+        .context("create CLI file datastore watcher")?;
+
+        for dir in &watch_dirs {
+            watcher
+                .watch(dir, RecursiveMode::NonRecursive)
+                .with_context(|| format!("watch CLI datastore directory {}", dir.display()))?;
+        }
+
+        let datastore = self.clone();
+        tokio::spawn(async move {
+            let _watcher = watcher;
+            while let Some(event) = event_rx.recv().await {
+                match event {
+                    Ok(event) if event_touches_watched_path(&event, &watched_paths) => {
+                        tokio::time::sleep(datastore.input.debounce).await;
+                        while let Ok(Ok(_)) = event_rx.try_recv() {}
+                        match datastore.load().await {
+                            Ok(snapshot) => {
+                                if snapshot_tx.send(Some(Arc::new(snapshot))).is_err() {
+                                    log::debug!("CLI file datastore subscriber dropped; exiting");
+                                    break;
+                                }
+                            }
+                            Err(err) => {
+                                log::error!(
+                                    "CLI file datastore reload failed; keeping previous configuration: {err:#}"
+                                );
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        log::warn!("CLI file datastore watch event failed: {err:#}");
+                    }
+                }
+            }
+        });
+
+        Ok(watch_to_change_stream(snapshot_rx))
+    }
+
+    fn label(&self) -> &'static str {
+        self.input.label
+    }
+}
+
+fn watch_directories(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs = BTreeSet::new();
+    for path in paths {
+        let dir = path.parent().unwrap_or_else(|| Path::new("."));
+        dirs.insert(dir.to_path_buf());
+    }
+    dirs.into_iter().collect()
+}
+
+fn event_touches_watched_path(event: &Event, watched_paths: &[PathBuf]) -> bool {
+    event.paths.iter().any(|event_path| {
+        watched_paths
+            .iter()
+            .any(|watched_path| paths_match(event_path, watched_path))
+    })
+}
+
+fn paths_match(event_path: &Path, watched_path: &Path) -> bool {
+    if event_path == watched_path {
+        return true;
+    }
+
+    // We watch the parent directory (not the file), so `notify` may report a
+    // sibling path that is not byte-identical to `watched_path` (for example a
+    // non-canonicalized form after an atomic rename). Matching on file name plus
+    // parent covers those cases without watching unrelated files.
+    event_path.file_name() == watched_path.file_name()
+        && event_path.parent() == watched_path.parent()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use futures_core::Stream;
+    use tacacsrs_datastore::ConfigDatastore;
+    use tokio::time::{timeout, Duration};
+
+    use super::*;
+    use crate::model::{
+        CliConfigSource, CliDatastoreInput, CliSecurity, CliSecurityInputs, CliServerInput,
+    };
+
+    fn temp_config(contents: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cli-file-datastore-{unique}.json"));
+        fs::write(&path, contents).expect("temp config should be written");
+        path
+    }
+
+    fn temp_file(prefix: &str, contents: &[u8]) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cli-file-datastore-{prefix}-{unique}"));
+        fs::write(&path, contents).expect("temp file should be written");
+        path
+    }
+
+    fn sample_key_der() -> Vec<u8> {
+        fs::read(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("tacacsrs_networking")
+                .join("examples")
+                .join("samples")
+                .join("client.key.der"),
+        )
+        .expect("sample DER key exists")
+    }
+
+    fn config(address: &str) -> String {
+        format!(
+            r#"{{
+                "ietf-system-tacacs-plus:tacacs-plus": {{
+                    "server": [{{
+                        "name": "primary",
+                        "server-type": "accounting",
+                        "address": "{address}",
+                        "port": 49,
+                        "shared-secret": "secret1"
+                    }}]
+                }}
+            }}"#
+        )
+    }
+
+    async fn next_change<S>(stream: &mut S) -> tacacsrs_datastore::ConfigChange
+    where
+        S: Stream<Item = tacacsrs_datastore::ConfigChange> + Unpin,
+    {
+        timeout(Duration::from_secs(5), futures_util::StreamExt::next(stream))
+            .await
+            .expect("change should arrive")
+            .expect("stream should yield change")
+    }
+
+    #[tokio::test]
+    async fn subscribe_emits_change_after_config_file_update() {
+        let path = temp_config(&config("192.0.2.10"));
+        let input =
+            CliDatastoreInput::new(CliConfigSource::YangFile { path: path.clone() }, "file")
+                .with_debounce(Duration::from_millis(50));
+        let datastore = CliFileDatastore::new(input);
+        let mut stream = datastore.subscribe().await.expect("subscribe should work");
+
+        fs::write(&path, config("192.0.2.11")).expect("config should update");
+
+        let change = next_change(&mut stream).await;
+        fs::remove_file(path).ok();
+
+        assert_eq!(change.config.server[0].address, "192.0.2.11");
+    }
+
+    #[tokio::test]
+    async fn subscribe_emits_change_after_certificate_file_update() {
+        let cert_path = temp_file("cert", b"cert-a");
+        let key_path = temp_file("key", &sample_key_der());
+        let input = CliDatastoreInput::new(
+            CliConfigSource::Inline {
+                servers: vec![CliServerInput::new("server-0", "192.0.2.10:49")],
+                security: CliSecurity::from_cli_inputs(CliSecurityInputs {
+                    use_tls: true,
+                    client_certificate: Some(cert_path.clone()),
+                    client_key: Some(key_path.clone()),
+                    ..Default::default()
+                }),
+            },
+            "cli",
+        )
+        .with_debounce(Duration::from_millis(50));
+        let datastore = CliFileDatastore::new(input);
+        let mut stream = datastore.subscribe().await.expect("subscribe should work");
+
+        fs::write(&cert_path, b"cert-b").expect("certificate should update");
+
+        let change = next_change(&mut stream).await;
+        fs::remove_file(cert_path).ok();
+        fs::remove_file(key_path).ok();
+
+        assert_eq!(change.delta.modified_servers, vec!["server-0".to_owned()]);
+    }
+}

--- a/libraries/tacacsrs_cli_datastore/src/files.rs
+++ b/libraries/tacacsrs_cli_datastore/src/files.rs
@@ -1,0 +1,110 @@
+use std::path::Path;
+
+use anyhow::Context;
+use rustls_pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
+use tacacsrs_config::crypto_types::PrivateKeyFormat;
+
+fn data_contains_pem_header(data: &[u8]) -> bool {
+    const PEM_HEADER: &[u8] = b"-----BEGIN";
+
+    data.windows(PEM_HEADER.len())
+        .any(|window| window == PEM_HEADER)
+}
+
+/// Normalize PEM or DER certificate data into DER bytes.
+///
+/// # Errors
+///
+/// Returns an error if the data is empty, PEM parsing fails, or the PEM file
+/// does not contain exactly one certificate.
+pub fn normalize_cli_certificate_data(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    if data.is_empty() {
+        anyhow::bail!("client certificate data is empty");
+    }
+
+    if !data_contains_pem_header(data) {
+        return Ok(data.to_vec());
+    }
+
+    let certificates = CertificateDer::pem_slice_iter(data)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| anyhow::anyhow!("failed to parse PEM client certificate: {err}"))?;
+
+    if certificates.len() != 1 {
+        anyhow::bail!("client certificate file must contain exactly one PEM certificate");
+    }
+
+    Ok(certificates[0].as_ref().to_vec())
+}
+
+/// Normalize PEM or DER private key data into DER bytes and its YANG key format.
+///
+/// # Errors
+///
+/// Returns an error if the data is empty or not a supported PKCS#1, SEC1, or
+/// PKCS#8 private key.
+pub fn normalize_cli_private_key_data(data: &[u8]) -> anyhow::Result<(Vec<u8>, PrivateKeyFormat)> {
+    if data.is_empty() {
+        anyhow::bail!("client private key data is empty");
+    }
+
+    let private_key = if data_contains_pem_header(data) {
+        PrivateKeyDer::from_pem_slice(data)
+            .map_err(|err| anyhow::anyhow!("failed to parse PEM client private key: {err}"))?
+    } else {
+        PrivateKeyDer::try_from(data).map_err(|_| {
+            anyhow::anyhow!(
+                "unsupported DER client private key format; expected PKCS#1, SEC1, or PKCS#8"
+            )
+        })?
+    };
+
+    let private_key_format = match &private_key {
+        PrivateKeyDer::Pkcs1(_) => PrivateKeyFormat::RsaPrivateKeyFormat,
+        PrivateKeyDer::Sec1(_) => PrivateKeyFormat::EcPrivateKeyFormat,
+        PrivateKeyDer::Pkcs8(_) => PrivateKeyFormat::OneAsymmetricKeyFormat,
+        _ => anyhow::bail!("unsupported client private key format"),
+    };
+
+    Ok((private_key.secret_der().to_vec(), private_key_format))
+}
+
+/// Read and normalize a client certificate file.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or parsed.
+pub fn load_client_certificate(path: &Path) -> anyhow::Result<Vec<u8>> {
+    let cert_data = std::fs::read(path)
+        .with_context(|| format!("Failed to read client certificate: {}", path.display()))?;
+    normalize_cli_certificate_data(&cert_data)
+        .with_context(|| format!("Failed to parse client certificate: {}", path.display()))
+}
+
+/// Read and normalize a client private key file.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or parsed.
+pub fn load_client_private_key(path: &Path) -> anyhow::Result<(Vec<u8>, PrivateKeyFormat)> {
+    let key_data = std::fs::read(path)
+        .with_context(|| format!("Failed to read client key: {}", path.display()))?;
+    normalize_cli_private_key_data(&key_data)
+        .with_context(|| format!("Failed to parse client key: {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_certificate_rejected() {
+        let err = normalize_cli_certificate_data(&[]).expect_err("empty cert should fail");
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn der_certificate_passthrough() {
+        assert_eq!(normalize_cli_certificate_data(b"der").unwrap(), b"der");
+    }
+}

--- a/libraries/tacacsrs_cli_datastore/src/lib.rs
+++ b/libraries/tacacsrs_cli_datastore/src/lib.rs
@@ -1,0 +1,22 @@
+#![doc = include_str!("../README.md")]
+#![allow(clippy::doc_markdown)]
+
+mod address;
+mod builder;
+mod datastore;
+mod files;
+mod model;
+
+pub use address::parse_host_port;
+pub use builder::{tacacs_plus_from_cli_input, tacacs_plus_from_file, tacacs_plus_from_str};
+pub use datastore::CliFileDatastore;
+pub use files::{
+    load_client_certificate, load_client_private_key, normalize_cli_certificate_data,
+    normalize_cli_private_key_data,
+};
+pub use model::{
+    CertKeyIdentity, CliConfigSource, CliDatastoreInput, CliSecurity, CliSecurityInputs,
+    CliSecurityMode, CliServerInput, PskKeyExchangeMode, PskKeyMaterial, TlsServerName,
+};
+#[cfg(feature = "psk")]
+pub use model::CliPskInputs;

--- a/libraries/tacacsrs_cli_datastore/src/model.rs
+++ b/libraries/tacacsrs_cli_datastore/src/model.rs
@@ -1,0 +1,277 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[cfg(feature = "psk")]
+use anyhow::Context;
+#[cfg(feature = "psk")]
+use base64::Engine as _;
+#[cfg(feature = "psk")]
+use tacacsrs_config::PskDheKeSupportedGroup;
+use tacacsrs_config::{TacacsPlusServerType, ValidationOptions};
+
+/// Parsed CLI inputs that can produce TACACS+ configuration.
+///
+/// Construct with [`CliDatastoreInput::new`] and the `with_*` methods; the
+/// fields are crate-private so the construction path stays the single source of
+/// defaults.
+#[derive(Debug, Clone)]
+pub struct CliDatastoreInput {
+    pub(crate) source: CliConfigSource,
+    pub(crate) validation_options: ValidationOptions,
+    pub(crate) label: &'static str,
+    pub(crate) debounce: Duration,
+}
+
+impl CliDatastoreInput {
+    /// Create a new input model with strict validation and a conservative debounce.
+    #[must_use]
+    pub fn new(source: CliConfigSource, label: &'static str) -> Self {
+        Self {
+            source,
+            validation_options: ValidationOptions::default(),
+            label,
+            debounce: Duration::from_millis(200),
+        }
+    }
+
+    #[must_use]
+    pub fn with_validation_options(mut self, validation_options: ValidationOptions) -> Self {
+        self.validation_options = validation_options;
+        self
+    }
+
+    #[must_use]
+    pub fn with_debounce(mut self, debounce: Duration) -> Self {
+        self.debounce = debounce;
+        self
+    }
+
+    #[must_use]
+    pub fn watched_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        match &self.source {
+            CliConfigSource::YangFile { path } => paths.push(path.clone()),
+            CliConfigSource::Inline { security, .. } => security.extend_watched_paths(&mut paths),
+        }
+        paths
+    }
+}
+
+/// Source of the TACACS+ root configuration.
+#[derive(Debug, Clone)]
+pub enum CliConfigSource {
+    /// A YANG JSON configuration file loaded (and watched) from disk.
+    YangFile { path: PathBuf },
+    /// Inline servers built from CLI flags. `security` applies uniformly to
+    /// every server in `servers`.
+    Inline {
+        servers: Vec<CliServerInput>,
+        security: CliSecurity,
+    },
+}
+
+/// Parsed CLI inputs for one TACACS+ server.
+#[derive(Debug, Clone)]
+pub struct CliServerInput {
+    pub name: String,
+    pub address: String,
+    pub server_type: TacacsPlusServerType,
+    pub timeout_seconds: u16,
+    pub single_connection: bool,
+    pub tls_server_name: Option<TlsServerName>,
+}
+
+impl CliServerInput {
+    #[must_use]
+    pub fn new(name: impl Into<String>, address: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            address: address.into(),
+            server_type: TacacsPlusServerType::all(),
+            timeout_seconds: 5,
+            single_connection: true,
+            tls_server_name: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_timeout_seconds(mut self, timeout_seconds: u16) -> Self {
+        self.timeout_seconds = timeout_seconds;
+        self
+    }
+
+    #[must_use]
+    pub fn with_single_connection(mut self, single_connection: bool) -> Self {
+        self.single_connection = single_connection;
+        self
+    }
+
+    #[must_use]
+    pub fn with_tls_server_name(mut self, tls_server_name: impl Into<String>) -> Self {
+        self.tls_server_name = Some(TlsServerName {
+            domain_name: tls_server_name.into(),
+            sni_enabled: true,
+        });
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TlsServerName {
+    pub domain_name: String,
+    pub sni_enabled: bool,
+}
+
+/// Security configuration derived from parsed CLI fields.
+///
+/// The security *mode* is orthogonal to `shared_secret`: a shared secret may
+/// accompany a TLS mode only as a migration aid, and is honored during
+/// construction solely when the active [`ValidationOptions`] allow it.
+#[derive(Debug, Clone)]
+pub struct CliSecurity {
+    pub mode: CliSecurityMode,
+    pub shared_secret: Option<String>,
+}
+
+impl CliSecurity {
+    /// Derive the security configuration from neutral CLI inputs.
+    ///
+    /// This is the single decision point that maps `--use-tls`, PSK, client
+    /// certificate, and shared-secret flags onto a [`CliSecurityMode`]. Both
+    /// `tacacsrs-agentd` and `tacon` funnel their parsed flags through here so
+    /// the mode-selection logic cannot drift between executables.
+    #[must_use]
+    pub fn from_cli_inputs(inputs: CliSecurityInputs) -> Self {
+        let shared_secret = inputs.shared_secret;
+
+        if !inputs.use_tls {
+            return Self {
+                mode: CliSecurityMode::PlainTcp,
+                shared_secret,
+            };
+        }
+
+        #[cfg(feature = "psk")]
+        if let Some(psk) = inputs.psk {
+            return Self {
+                mode: CliSecurityMode::TlsPsk {
+                    identity: psk.identity,
+                    key: psk.key,
+                    exchange: psk.exchange,
+                    groups: psk.groups,
+                },
+                shared_secret,
+            };
+        }
+
+        let mode = match (inputs.client_certificate, inputs.client_key) {
+            (Some(certificate_path), Some(private_key_path)) => {
+                CliSecurityMode::TlsClientCertificate {
+                    identity: CertKeyIdentity::new(certificate_path, private_key_path),
+                }
+            }
+            _ => CliSecurityMode::TlsServerAuthentication,
+        };
+
+        Self {
+            mode,
+            shared_secret,
+        }
+    }
+
+    pub(crate) fn extend_watched_paths(&self, paths: &mut Vec<PathBuf>) {
+        if let CliSecurityMode::TlsClientCertificate { identity } = &self.mode {
+            identity.extend_watched_paths(paths);
+        }
+    }
+}
+
+/// Security mode selected by the CLI, independent of any shared secret.
+#[derive(Debug, Clone)]
+pub enum CliSecurityMode {
+    /// Plain TCP with optional TACACS+ obfuscation via a shared secret.
+    PlainTcp,
+    /// TLS with server authentication only (no client identity).
+    TlsServerAuthentication,
+    /// TLS with a client certificate identity read from disk.
+    TlsClientCertificate { identity: CertKeyIdentity },
+    /// TLS 1.3 with an externally provisioned pre-shared key.
+    #[cfg(feature = "psk")]
+    TlsPsk {
+        identity: String,
+        key: PskKeyMaterial,
+        exchange: PskKeyExchangeMode,
+        groups: Vec<PskDheKeSupportedGroup>,
+    },
+}
+
+/// Neutral security inputs collected from an executable's parsed CLI.
+///
+/// Each executable fills this from its own clap struct;
+/// [`CliSecurity::from_cli_inputs`] owns the decision logic so it stays
+/// identical across executables.
+#[derive(Debug, Clone, Default)]
+pub struct CliSecurityInputs {
+    pub use_tls: bool,
+    pub shared_secret: Option<String>,
+    pub client_certificate: Option<PathBuf>,
+    pub client_key: Option<PathBuf>,
+    #[cfg(feature = "psk")]
+    pub psk: Option<CliPskInputs>,
+}
+
+/// TLS 1.3 PSK inputs collected from an executable's parsed CLI.
+#[cfg(feature = "psk")]
+#[derive(Debug, Clone)]
+pub struct CliPskInputs {
+    pub identity: String,
+    pub key: PskKeyMaterial,
+    pub exchange: PskKeyExchangeMode,
+    pub groups: Vec<PskDheKeSupportedGroup>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CertKeyIdentity {
+    pub certificate_path: PathBuf,
+    pub private_key_path: PathBuf,
+}
+
+impl CertKeyIdentity {
+    #[must_use]
+    pub fn new(certificate_path: impl Into<PathBuf>, private_key_path: impl Into<PathBuf>) -> Self {
+        Self {
+            certificate_path: certificate_path.into(),
+            private_key_path: private_key_path.into(),
+        }
+    }
+
+    pub(crate) fn extend_watched_paths(&self, paths: &mut Vec<PathBuf>) {
+        paths.push(self.certificate_path.clone());
+        paths.push(self.private_key_path.clone());
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PskKeyExchangeMode {
+    PskDhe,
+    PskOnly,
+}
+
+/// PSK bytes as they are supplied by each executable's CLI contract.
+#[derive(Debug, Clone)]
+pub enum PskKeyMaterial {
+    Raw(Vec<u8>),
+    StandardBase64(String),
+}
+
+impl PskKeyMaterial {
+    #[cfg(feature = "psk")]
+    pub(crate) fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+        match self {
+            Self::Raw(bytes) => Ok(bytes),
+            Self::StandardBase64(value) => base64::engine::general_purpose::STANDARD
+                .decode(value)
+                .context("--psk-key must be standard base64-encoded PSK bytes"),
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors the way CLI and file-based configuration is handled in `tacacsrs_agentd` by introducing and integrating the new `tacacsrs_cli_datastore` library. The changes replace legacy configuration code with a more modular and reload-friendly approach, streamline how configuration is constructed from CLI arguments, and update dependencies and tests accordingly.

**Integration of new CLI datastore and configuration handling:**

* Added `tacacsrs_cli_datastore` as a workspace member and dependency for `tacacsrs_agentd` and `tacon`, enabling a unified and hot-reloadable approach to CLI and file-based configuration. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R13) [[2]](diffhunk://#diff-3feef18075ec84731d64e23fe73d7f5c2cc4bca7b6a8aab7369a00fb69a74ab5R19) [[3]](diffhunk://#diff-e8502cc83ac40cabc2f0ab68a59c368643b1c7c8900c1995017e6cf333802455R22)
* Refactored the main configuration construction in `tacacsrs_agentd/src/main.rs` to use `CliFileDatastore` and related types from `tacacsrs_cli_datastore`, replacing legacy builder functions and normalization logic. [[1]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R3-R20) [[2]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L33-L106) [[3]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L136-L267) [[4]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L282-R137) [[5]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L308-R166)
* Updated the PSK feature gating to include the new CLI datastore and ensure correct feature propagation. [[1]](diffhunk://#diff-3feef18075ec84731d64e23fe73d7f5c2cc4bca7b6a8aab7369a00fb69a74ab5L28-R29) [[2]](diffhunk://#diff-e8502cc83ac40cabc2f0ab68a59c368643b1c7c8900c1995017e6cf333802455L31-R31)

**Test and code cleanup:**

* Replaced direct calls to legacy config builder functions in tests with the new `tacacsrs_cli_datastore` APIs, ensuring tests validate the new configuration path. [[1]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L482-R340) [[2]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L577-R425) [[3]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L596-R445) [[4]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L610-R460) [[5]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L625-R476) [[6]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L711-R563) [[7]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L726-R579) [[8]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L815-R669)
* Removed legacy normalization and parsing functions that are now handled by the new datastore logic.

These changes modernize and simplify the configuration flow, making it easier to maintain and extend in the future.