### PR TITLE
feat: add multi-stage container build for tacacsrs-agentd and update documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Keep the Docker build context small and reproducible. This file applies to
+# builds whose context is the workspace root (see containers/*/Dockerfile).
+#
+# The default is deny-all: only Cargo workspace metadata and crate build inputs
+# needed by the source build are sent to the Docker daemon. This prevents local
+# generated files, release artifacts, notes, docs, and unrelated worktree state
+# from accidentally becoming part of the container build context.
+
+**
+
+# Workspace-level build metadata.
+!Cargo.toml
+!Cargo.lock
+!.cargo/
+!.cargo/config.toml
+
+# Workspace crate directories. Parent directories must be unignored before their
+# selected children can be included.
+!libraries/
+!executables/
+!libraries/*/
+!executables/*/
+
+# Re-ignore crate contents after opening the parent directories. The specific
+# build inputs below opt back in.
+libraries/*/**
+executables/*/**
+
+# Cargo package metadata and build scripts.
+!libraries/*/Cargo.toml
+!executables/*/Cargo.toml
+!libraries/*/build.rs
+!executables/*/build.rs
+!libraries/*/README.md
+!executables/*/README.md
+!libraries/*/readme.md
+!executables/*/readme.md
+
+# Rust sources and build-time generated-code inputs.
+!libraries/*/src/
+!libraries/*/src/**
+!executables/*/src/
+!executables/*/src/**
+!libraries/*/proto/
+!libraries/*/proto/**
+!executables/*/proto/
+!executables/*/proto/**
+
+# YANG/config generation inputs used by tacacsrs-config.
+!libraries/tacacsrs_config/yang/
+!libraries/tacacsrs_config/yang/**
+
+# TLS fixture files used by tacacsrs-agentd unit tests.
+!libraries/tacacsrs_networking/examples/
+!libraries/tacacsrs_networking/examples/samples/
+!libraries/tacacsrs_networking/examples/samples/**
+!lde/
+!lde/containers/
+!lde/containers/config/
+!lde/containers/config/certificates/
+!lde/containers/config/certificates/client.*

--- a/.github/steps/container-image/action.yml
+++ b/.github/steps/container-image/action.yml
@@ -1,0 +1,70 @@
+name: Container Image
+description: Build and optionally publish the tacacsrs-agentd container image
+
+inputs:
+  versions:
+    description: 'JSON map of crate-name to version. tacacsrs-agentd is used as the image tag when present.'
+    required: false
+    default: '{}'
+  registry:
+    description: 'Container registry and namespace used for image tags, for example ghcr.io/authscaffold'
+    required: true
+  image-name:
+    description: 'Container image repository name'
+    required: true
+  publish:
+    description: 'Push the image after a successful build'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Compute container image version
+      id: container-version
+      shell: bash
+      env:
+        VERSIONS: ${{ inputs.versions }}
+      run: |
+        set -euo pipefail
+
+        version=$(jq -r '."tacacsrs-agentd" // empty' <<< "${VERSIONS}")
+        if [ -z "${version}" ]; then
+          version=dev
+        fi
+
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "Using container image version: ${version}"
+
+    - name: Check Docker Buildx
+      shell: bash
+      run: docker buildx version
+
+    - name: Login to container registry
+      if: inputs.publish == 'true'
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        registry_host="${REGISTRY%%/*}"
+        echo "${GITHUB_TOKEN}" | docker login "${registry_host}" -u "${GITHUB_ACTOR}" --password-stdin
+
+    - name: Build tacacsrs-agentd container image
+      shell: bash
+      run: >-
+        make -C containers/tacacsrs-agentd build
+        BUILD_VERSION=${{ steps.container-version.outputs.version }}
+        REGISTRY=${{ inputs.registry }}
+        IMAGE_NAME=${{ inputs.image-name }}
+
+    - name: Publish tacacsrs-agentd container image
+      if: inputs.publish == 'true'
+      shell: bash
+      run: >-
+        make -C containers/tacacsrs-agentd push
+        BUILD_VERSION=${{ steps.container-version.outputs.version }}
+        REGISTRY=${{ inputs.registry }}
+        IMAGE_NAME=${{ inputs.image-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
       include-fmt: false
       include-proto-compat: false
       include-outdated: false
-      include-container-publish: ${{ github.event_name == 'push' && github.repository_owner == 'AuthScaffold' && needs.release-policy.outputs.skip-release != 'true' && needs.compute-versions.outputs.has-release == 'true' }}
       container-registry: ghcr.io/authscaffold
       products: |
         [
@@ -133,9 +132,8 @@ jobs:
         if: needs.pipeline.result != 'success'
         run: exit 1
 
-  # ── Release: tag and publish (only on push to main) ──────
-  release:
-    name: Release
+  container-publish:
+    name: Container Publish
     runs-on: ubuntu-latest
     needs: [ci-success, compute-versions, release-policy]
     if: >-
@@ -143,6 +141,32 @@ jobs:
       github.repository_owner == 'AuthScaffold' &&
       needs.release-policy.outputs.skip-release != 'true' &&
       needs.ci-success.result == 'success' &&
+      needs.compute-versions.outputs.has-release == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build and publish tacacsrs-agentd container image
+        uses: ./.github/steps/container-image
+        with:
+          versions: ${{ needs.compute-versions.outputs.versions || '{}' }}
+          registry: ghcr.io/authscaffold
+          image-name: tacacsrs-agentd
+          publish: 'true'
+
+  # ── Release: tag and publish (only on push to main) ──────
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ci-success, compute-versions, release-policy, container-publish]
+    if: >-
+      github.event_name == 'push' &&
+      github.repository_owner == 'AuthScaffold' &&
+      needs.release-policy.outputs.skip-release != 'true' &&
+      needs.ci-success.result == 'success' &&
+      needs.container-publish.result == 'success' &&
       needs.compute-versions.outputs.has-release == 'true'
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,13 @@ jobs:
     permissions:
       checks: write
       contents: read
-      packages: read
+      packages: write
     with:
       include-fmt: false
       include-proto-compat: false
       include-outdated: false
+      include-container-publish: ${{ github.event_name == 'push' && github.repository_owner == 'AuthScaffold' && needs.release-policy.outputs.skip-release != 'true' && needs.compute-versions.outputs.has-release == 'true' }}
+      container-registry: ghcr.io/authscaffold
       products: |
         [
           {"os": "ubuntu-latest", "target": "x86_64-unknown-linux-gnu", "asset_name": "tacon-linux-gnu-x86_64", "package_name": "tacon", "package_root": "executables/tacon", "artifact_name": "tacon", "artifact_kind": "bin", "features": "psk", "sbom_describe": "binaries", "man_page_name": "tacon", "debian_package": true},

--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -406,7 +406,7 @@ jobs:
   container-build:
     name: Container Build
     needs: [testing]
-    if: ${{ !cancelled() && !failure() && inputs.include-container-build && !inputs.include-container-publish }}
+    if: ${{ !cancelled() && !failure() && inputs.include-container-build }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -420,25 +420,6 @@ jobs:
           versions: ${{ inputs.versions }}
           registry: ${{ inputs.container-registry }}
           image-name: ${{ inputs.container-image-name }}
-
-  container-publish:
-    name: Container Publish
-    needs: [testing]
-    if: ${{ !cancelled() && !failure() && inputs.include-container-build && inputs.include-container-publish }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Build and publish tacacsrs-agentd container image
-        uses: ./.github/steps/container-image
-        with:
-          versions: ${{ inputs.versions }}
-          registry: ${{ inputs.container-registry }}
-          image-name: ${{ inputs.container-image-name }}
-          publish: 'true'
 
   finalize-release-assets:
     name: Finalize Release Assets
@@ -478,7 +459,6 @@ jobs:
       - testing
       - official-build
       - container-build
-      - container-publish
       - finalize-release-assets
     steps:
       - name: Check all jobs passed

--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -23,6 +23,26 @@ on:
         required: false
         default: true
         type: boolean
+      include-container-build:
+        description: 'Include container image build validation'
+        required: false
+        default: true
+        type: boolean
+      include-container-publish:
+        description: 'Publish the container image after a successful build'
+        required: false
+        default: false
+        type: boolean
+      container-registry:
+        description: 'Container registry and namespace used for image tags, for example ghcr.io/authscaffold'
+        required: false
+        default: 'ghcr.io/authscaffold'
+        type: string
+      container-image-name:
+        description: 'Container image repository name'
+        required: false
+        default: 'tacacsrs-agentd'
+        type: string
       include-clippy-nursery:
         description: 'Include clippy nursery lints job'
         required: false
@@ -383,6 +403,43 @@ jobs:
           path: packaged/*
           retention-days: 7
 
+  container-build:
+    name: Container Build
+    needs: [testing]
+    if: ${{ !cancelled() && !failure() && inputs.include-container-build && !inputs.include-container-publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build tacacsrs-agentd container image
+        uses: ./.github/steps/container-image
+        with:
+          versions: ${{ inputs.versions }}
+          registry: ${{ inputs.container-registry }}
+          image-name: ${{ inputs.container-image-name }}
+
+  container-publish:
+    name: Container Publish
+    needs: [testing]
+    if: ${{ !cancelled() && !failure() && inputs.include-container-build && inputs.include-container-publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build and publish tacacsrs-agentd container image
+        uses: ./.github/steps/container-image
+        with:
+          versions: ${{ inputs.versions }}
+          registry: ${{ inputs.container-registry }}
+          image-name: ${{ inputs.container-image-name }}
+          publish: 'true'
+
   finalize-release-assets:
     name: Finalize Release Assets
     needs: [official-build]
@@ -420,6 +477,8 @@ jobs:
       - pre-tests
       - testing
       - official-build
+      - container-build
+      - container-publish
       - finalize-release-assets
     steps:
       - name: Check all jobs passed

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -1,0 +1,32 @@
+# Top-level container build orchestrator.
+#
+# Runs the requested target in every immediate subdirectory that contains a
+# Makefile, mirroring the per-image container Makefiles. This scales to
+# additional images (for example, the IPC emulator) without changing this file.
+#
+# Examples:
+#   make build
+#   make build REGISTRY=ghcr.io/authscaffold BUILD_VERSION=2026.0706.1
+#   make test
+
+BUILD_VERSION ?= dev
+REGISTRY ?= tacacsrs
+
+# Every immediate subdirectory that has its own Makefile is a buildable image.
+SUBDIRS := $(patsubst %/Makefile,%,$(wildcard */Makefile))
+
+.PHONY: all build push test clean
+
+all: build
+
+build push clean:
+	@for dir in $(SUBDIRS); do \
+		echo "==> $@ in $$dir"; \
+		$(MAKE) -C $$dir $@ BUILD_VERSION=$(BUILD_VERSION) REGISTRY=$(REGISTRY) || exit 1; \
+	done
+
+test:
+	@for dir in $(SUBDIRS); do \
+		echo "==> test in $$dir"; \
+		$(MAKE) -C $$dir test || exit 1; \
+	done

--- a/containers/tacacsrs-agentd/Dockerfile
+++ b/containers/tacacsrs-agentd/Dockerfile
@@ -1,0 +1,108 @@
+# syntax=docker/dockerfile:1.7
+#
+# Container image for the central TACACS+ client agent (`tacacsrs-agentd`).
+#
+# This is a multi-stage build:
+#   base    -> Rust toolchain plus the build dependencies for the `psk` feature
+#   test    -> runs the agent daemon's test suite (used by `make test`)
+#   build   -> compiles the `tacacsrs-agentd` binary with BuildKit caches
+#   runtime -> minimal image that ships only the binary and its runtime deps
+#
+# The build context MUST be the workspace root so the whole Cargo workspace
+# (manifests plus every crate under `libraries/` and `executables/`) is visible.
+# The container Makefile in this directory sets the context accordingly.
+#
+# The base images are overridable build arguments so downstream builders can
+# swap in their own toolchain or hardened runtime base without editing this
+# file, for example:
+#
+#   docker buildx build \
+#       --build-arg BUILDER_IMAGE=<registry>/rust:1.90 \
+#       --build-arg RUNTIME_IMAGE=<registry>/debian:bookworm-slim \
+#       --file Dockerfile ../..
+
+ARG BUILDER_IMAGE=docker.io/library/rust:1.90-bookworm
+ARG RUNTIME_IMAGE=docker.io/library/debian:bookworm-slim
+
+# -----------------------------------------------------------------------------
+# base: toolchain and build dependencies
+# -----------------------------------------------------------------------------
+FROM ${BUILDER_IMAGE} AS base
+
+# `pkg-config` and `libssl-dev` are required to build the `psk` feature, which
+# links against the system OpenSSL. `protoc` is provided by the vendored
+# `protoc-bin-vendored` crate, so it does not need to be installed here.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy the Cargo workspace. All workspace members must be present for cargo to
+# resolve the virtual workspace, even when building a single package.
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo ./.cargo
+COPY libraries ./libraries
+COPY executables ./executables
+
+# The networking crate sample certificate files are symlinks in the worktree.
+# Materialize the files in the Linux build image so tests can follow the paths
+# reliably even when the host checkout was created on Windows.
+RUN rm -f libraries/tacacsrs_networking/examples/samples/client.*
+COPY lde/containers/config/certificates/client.* ./libraries/tacacsrs_networking/examples/samples/
+
+# -----------------------------------------------------------------------------
+# test: run the agent daemon test suite
+# -----------------------------------------------------------------------------
+FROM base AS test
+ARG FEATURES=psk
+# CACHEBUST lets `make test` force a fresh test run even when the source layers
+# are cached (pass --build-arg CACHEBUST=$(date +%s)).
+ARG CACHEBUST=0
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo test --locked -p tacacsrs-agentd --features "${FEATURES}"
+
+# -----------------------------------------------------------------------------
+# build: compile the release binary
+# -----------------------------------------------------------------------------
+FROM base AS build
+ARG PROFILE=release
+ARG FEATURES=psk
+# The cache mount speeds up rebuilds but is not part of the image layer, so the
+# freshly built binary is copied out of the cached target dir within the same
+# RUN before the mount is unmounted.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    if [ "${PROFILE}" = "debug" ]; then \
+        cargo build --locked -p tacacsrs-agentd --features "${FEATURES}"; \
+    else \
+        cargo build --locked --profile "${PROFILE}" -p tacacsrs-agentd --features "${FEATURES}"; \
+    fi \
+    && cp "target/${PROFILE}/tacacsrs-agentd" /build/tacacsrs-agentd
+
+# -----------------------------------------------------------------------------
+# runtime: minimal image with just the binary and its runtime dependencies
+# -----------------------------------------------------------------------------
+FROM ${RUNTIME_IMAGE} AS runtime
+
+# `libssl3` satisfies the OpenSSL runtime for the `psk` feature and
+# `ca-certificates` provides the trust store for certificate-based TLS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl3 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /run/tacacs
+
+COPY --from=build /build/tacacsrs-agentd /usr/sbin/tacacsrs-agentd
+
+# The agent runs as a foreground process. The default CMD mirrors the SONiC
+# systemd unit and can be overridden at `docker run` time for other environments
+# (for example, dropping `--sonic` when not reading SONiC ConfigDB).
+ENTRYPOINT ["/usr/sbin/tacacsrs-agentd"]
+CMD ["--sonic", "--listen-endpoint", "/run/tacacs/tacacs.sock", "--socket-mode", "666", "-vv"]

--- a/containers/tacacsrs-agentd/Makefile
+++ b/containers/tacacsrs-agentd/Makefile
@@ -1,0 +1,74 @@
+# Container build for the central TACACS+ client agent (`tacacsrs-agentd`).
+#
+# Targets:
+#   build   Build the image with `docker buildx` (loads it into the local docker)
+#   push    Push the built image to $(REGISTRY)
+#   test    Run the agent daemon test suite inside the build container
+#   clean   Remove local Cargo build artifacts
+#
+# The image name and version are overridable, for example:
+#   make build REGISTRY=ghcr.io/authscaffold BUILD_VERSION=2026.0706.1
+
+IMAGE_NAME := tacacsrs-agentd
+DOCKERFILE := Dockerfile
+
+# The build context is the workspace root so the Dockerfile can see the whole
+# Cargo workspace (manifests plus every crate under libraries/ and executables/).
+CONTEXT := ../..
+
+# Space-separated list of target platforms. Non-amd64 tags are suffixed with the
+# architecture. arm64 is left commented until it is part of the support matrix.
+PLATFORMS := linux/amd64 # linux/arm64
+
+# Image tag version. Override in CI with the computed release version.
+BUILD_VERSION ?= dev
+
+# Container registry / namespace. Defaults to a bare local namespace so the
+# open-source build never references a private registry. Override for your own
+# registry, e.g. REGISTRY=ghcr.io/authscaffold.
+REGISTRY ?= tacacsrs
+
+.PHONY: all build push test clean
+
+all: build
+
+build:
+	@echo "==> Building $(IMAGE_NAME)..."
+	@for p in $(PLATFORMS); do \
+		arch=$$(echo $$p | cut -d/ -f2-); \
+		tag=$(BUILD_VERSION); \
+		if [ "$$arch" != "amd64" ]; then tag="$$tag-$$arch"; fi; \
+		full_tag=$(REGISTRY)/$(IMAGE_NAME):$$tag; \
+		echo "Building for $$p with tag $$full_tag..."; \
+		docker buildx build \
+			--platform $$p \
+			--file $(DOCKERFILE) \
+			--tag $$full_tag \
+			--load \
+			$(CONTEXT); \
+	done
+
+push:
+	@echo "==> Pushing $(IMAGE_NAME)..."
+	@for p in $(PLATFORMS); do \
+		arch=$$(echo $$p | cut -d/ -f2-); \
+		tag=$(BUILD_VERSION); \
+		if [ "$$arch" != "amd64" ]; then tag="$$tag-$$arch"; fi; \
+		full_tag=$(REGISTRY)/$(IMAGE_NAME):$$tag; \
+		echo "Pushing $$full_tag..."; \
+		docker push $$full_tag; \
+	done
+
+test:
+	@echo "==> Testing $(IMAGE_NAME)..."
+	@for p in $(PLATFORMS); do \
+		docker buildx build \
+			--platform $$p \
+			--file $(DOCKERFILE) \
+			--target test \
+			--build-arg CACHEBUST=$$(date +%s) \
+			$(CONTEXT); \
+	done
+
+clean:
+	@cargo clean

--- a/docs/sonic-build-guide.md
+++ b/docs/sonic-build-guide.md
@@ -107,6 +107,38 @@ Reference that path from `/etc/bash_plugins.conf`:
 plugin=/usr/lib/x86_64-linux-gnu/security/tacacsrs_bash_plugin.so
 ```
 
+## Container image
+
+For container-based delivery of the agent, a multi-stage container build for
+`tacacsrs-agentd` lives under `containers/tacacsrs-agentd/`. It compiles the
+daemon from source with the `psk` feature and ships a minimal glibc runtime
+image, so it stays compatible with SONiC's Debian userspace.
+
+Build and test the image with the container Makefiles (run from a Linux
+environment or WSL with Docker BuildKit available):
+
+```bash
+# Build just the agent image
+make -C containers/tacacsrs-agentd build
+
+# Run the agent daemon test suite inside the build container
+make -C containers/tacacsrs-agentd test
+
+# Build every container image in the repo
+make -C containers build
+```
+
+The image name, tag, and registry are overridable:
+
+```bash
+make -C containers/tacacsrs-agentd build REGISTRY=<your-registry> BUILD_VERSION=<version>
+```
+
+The toolchain and runtime base images are `docker buildx` build arguments
+(`BUILDER_IMAGE` and `RUNTIME_IMAGE`), so downstream builders can substitute
+their own bases without editing the Dockerfile. The default `ENTRYPOINT`/`CMD`
+mirrors the SONiC systemd unit and can be overridden at `docker run` time.
+
 ## Verification
 
 Before enabling SONiC command authorization broadly, verify that:


### PR DESCRIPTION
This pull request introduces a complete, reproducible container build system for the `tacacsrs-agentd` agent, including a multi-stage Dockerfile, orchestrating Makefiles, and CI integration for building and publishing images. It also updates documentation to describe the new container workflow. The changes ensure that container images are built from a minimal, tightly controlled context, support multi-platform builds, and are automatically validated and published in CI.

**Containerization and Build System:**

* Added a multi-stage `Dockerfile` for `tacacsrs-agentd` supporting build, test, and minimal runtime images, with overridable toolchain/runtime bases and a default entrypoint matching SONiC's systemd unit. (`containers/tacacsrs-agentd/Dockerfile`)
* Introduced dedicated Makefiles for both the agent image and all containers, enabling standardized build, test, and publish workflows, multi-platform support, and easy registry/tag overrides. (`containers/tacacsrs-agentd/Makefile`, `containers/Makefile`) [[1]](diffhunk://#diff-e01e1b23226e0e2c16cb34db5b12a4aca16c692a9edf64d03735e8506504e3f3R1-R74) [[2]](diffhunk://#diff-50a44f7942777cd880074abc01ff1ca6fce98951639f48bbab8453ac85f41e7eR1-R32)
* Added a `.dockerignore` at the workspace root to restrict Docker build context to only necessary Cargo workspace metadata and crate sources, minimizing build size and risk of leaking local files. (`.dockerignore`)

**CI/CD Integration:**

* Implemented a reusable GitHub Actions step to build and optionally publish the container image, including registry login and version tagging, and integrated it into the main workflow with new jobs for build and publish. (`.github/steps/container-image/action.yml`, `.github/workflows/reusable-pipeline.yml`, `.github/workflows/ci.yml`) [[1]](diffhunk://#diff-4a1c0b266fa566a72ebd5f1d77e5d83669f5f5715a4b14eb343e5cf92a17d190R1-R70) [[2]](diffhunk://#diff-5fe84e9f67a58184c1cf92f8642933831edcdefcd19d4110ed05bf8014a747d8R26-R45) [[3]](diffhunk://#diff-5fe84e9f67a58184c1cf92f8642933831edcdefcd19d4110ed05bf8014a747d8R406-R442) [[4]](diffhunk://#diff-5fe84e9f67a58184c1cf92f8642933831edcdefcd19d4110ed05bf8014a747d8R480-R481) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL109-R115)

**Documentation:**

* Updated the SONiC build guide to document the new container image build/test workflow, usage, and customization options. (`docs/sonic-build-guide.md`)