### PR TITLE
feat: implement TACACS+ configuration filters to prevent proxy self-loop scenarios

### DIFF
--- a/executables/tacacsrs_agentd/README.md
+++ b/executables/tacacsrs_agentd/README.md
@@ -11,6 +11,13 @@ Use `--service-mode client-api`, `--service-mode tacacs-proxy`, or
 flag is omitted, the daemon runs `client-api` by default and runs `both` when
 `--proxy-endpoint` is supplied. Proxy modes require `--proxy-endpoint`.
 
+When the raw TACACS+ proxy listens on a TCP endpoint, do not configure that same
+endpoint as an upstream TACACS+ server. Doing so would cause the proxy to send
+client traffic back into itself and can create a packet storm. To guard against
+this, the daemon removes upstream entries whose address and port parse or resolve
+to the local TCP proxy endpoint, including loopback IPv4, loopback IPv6, and
+hostnames such as `localhost`.
+
 ## TLS Client Certificates and Keys
 
 Use `--client-certificate` and `--client-key` with `--use-tls` when the upstream TACACS+ server requires the daemon to present a TLS client identity.

--- a/executables/tacacsrs_agentd/src/config_filter.rs
+++ b/executables/tacacsrs_agentd/src/config_filter.rs
@@ -1,0 +1,279 @@
+//! Runtime TACACS+ configuration filters composed by the daemon entry point.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use futures_util::future::{BoxFuture, FutureExt};
+use tacacsrs_agent::EnabledServices;
+use tacacsrs_agent_client::IpcEndpoint;
+use tacacsrs_config::{TacacsPlus, TacacsPlusServer};
+
+/// Filters a validated TACACS+ configuration before it is applied to runtime state.
+pub(crate) trait TacacsPlusFilter: Send + Sync {
+    /// Return the configuration snapshot that should be applied to the daemon.
+    fn filter(&self, tacacs_plus: TacacsPlus) -> BoxFuture<'_, TacacsPlus>;
+}
+
+/// Filter implementation that preserves every server unchanged.
+#[derive(Debug, Default)]
+pub(crate) struct NoopTacacsPlusFilter;
+
+impl TacacsPlusFilter for NoopTacacsPlusFilter {
+    fn filter(&self, tacacs_plus: TacacsPlus) -> BoxFuture<'_, TacacsPlus> {
+        async move { tacacs_plus }.boxed()
+    }
+}
+
+/// Filter that removes upstream servers targeting the local TCP proxy endpoint.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProxySelfLoopFilter {
+    proxy_endpoint: SocketAddr,
+}
+
+impl ProxySelfLoopFilter {
+    /// Create a filter for the local TCP proxy endpoint.
+    #[must_use]
+    pub(crate) const fn new(proxy_endpoint: SocketAddr) -> Self {
+        Self { proxy_endpoint }
+    }
+
+    async fn filter_proxy_self_loop_servers(&self, mut tacacs_plus: TacacsPlus) -> TacacsPlus {
+        let original_server_count = tacacs_plus.server.len();
+        let mut retained = Vec::with_capacity(original_server_count);
+        for server in tacacs_plus.server {
+            if upstream_server_targets_proxy_endpoint(&server, self.proxy_endpoint).await {
+                log::warn!(
+                    "Ignoring upstream TACACS+ server '{}' at {}:{} because it resolves to the local TACACS+ proxy endpoint {}; keeping it would proxy client traffic back into this daemon",
+                    server.name,
+                    server.address,
+                    server.port,
+                    self.proxy_endpoint,
+                );
+            } else {
+                retained.push(server);
+            }
+        }
+
+        let filtered_count = original_server_count.saturating_sub(retained.len());
+        tacacs_plus.server = retained;
+
+        if filtered_count > 0 {
+            log::info!(
+                "Filtered {filtered_count} upstream TACACS+ server(s) that target the local proxy endpoint {}",
+                self.proxy_endpoint,
+            );
+        }
+        if original_server_count > 0 && tacacs_plus.server.is_empty() {
+            log::warn!(
+                "All configured upstream TACACS+ servers target the local proxy endpoint {}; waiting for a non-looping upstream configuration",
+                self.proxy_endpoint,
+            );
+        }
+
+        tacacs_plus
+    }
+}
+
+impl TacacsPlusFilter for ProxySelfLoopFilter {
+    fn filter(&self, tacacs_plus: TacacsPlus) -> BoxFuture<'_, TacacsPlus> {
+        async move { self.filter_proxy_self_loop_servers(tacacs_plus).await }.boxed()
+    }
+}
+
+/// Compose the runtime config filter for the selected daemon services.
+#[must_use]
+pub(crate) fn config_filter_from_runtime_options(
+    enabled_services: EnabledServices,
+    proxy_endpoint: Option<&IpcEndpoint>,
+) -> Arc<dyn TacacsPlusFilter> {
+    if !enabled_services.tacacs_proxy() {
+        return Arc::new(NoopTacacsPlusFilter);
+    }
+
+    match proxy_endpoint {
+        Some(IpcEndpoint::Tcp(address)) => Arc::new(ProxySelfLoopFilter::new(*address)),
+        _ => Arc::new(NoopTacacsPlusFilter),
+    }
+}
+
+async fn upstream_server_targets_proxy_endpoint(
+    server: &TacacsPlusServer,
+    proxy_endpoint: SocketAddr,
+) -> bool {
+    if server.port != proxy_endpoint.port() {
+        return false;
+    }
+
+    if let Ok(address) = server.address.parse::<IpAddr>() {
+        return SocketAddr::new(address, server.port) == proxy_endpoint;
+    }
+
+    match tokio::net::lookup_host((server.address.as_str(), server.port)).await {
+        Ok(mut addresses) => addresses.any(|address| address == proxy_endpoint),
+        Err(error) => {
+            log::warn!(
+                "Failed to resolve upstream TACACS+ server '{}' at {}:{} while checking for a local proxy self-loop: {error}; keeping the server",
+                server.name,
+                server.address,
+                server.port,
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        config_filter_from_runtime_options, NoopTacacsPlusFilter, ProxySelfLoopFilter,
+        TacacsPlusFilter,
+    };
+    use tacacsrs_agent::EnabledServices;
+    use tacacsrs_agent_client::IpcEndpoint;
+    use tacacsrs_config::{TacacsPlus, TacacsPlusBuilder, TacacsPlusServerBuilder};
+    use tacacsrs_config::TacacsPlusServerType;
+
+    fn test_config_from_host_ports(addresses: &[(&str, u16)]) -> TacacsPlus {
+        addresses
+            .iter()
+            .enumerate()
+            .map(|(index, (address, port))| {
+                TacacsPlusServerBuilder::new(
+                    format!("server-{index}"),
+                    TacacsPlusServerType::AUTHENTICATION
+                        | TacacsPlusServerType::AUTHORIZATION
+                        | TacacsPlusServerType::ACCOUNTING,
+                    (*address).to_owned(),
+                    *port,
+                )
+                .with_shared_secret("test-secret".to_owned())
+            })
+            .fold(TacacsPlusBuilder::new(), TacacsPlusBuilder::with_server_builder)
+            .build()
+            .expect("test config should be valid")
+    }
+
+    #[tokio::test]
+    async fn runtime_options_select_proxy_filter_for_enabled_tcp_proxy() {
+        let endpoint = Some(
+            "127.0.0.1:9050"
+                .parse::<IpcEndpoint>()
+                .expect("TCP endpoint should parse"),
+        );
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9050), ("192.0.2.20", 49)]);
+        let filter =
+            config_filter_from_runtime_options(EnabledServices::TACACS_PROXY, endpoint.as_ref());
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "192.0.2.20");
+    }
+
+    #[tokio::test]
+    async fn runtime_options_select_noop_filter_when_proxy_is_disabled() {
+        let endpoint = Some(
+            "127.0.0.1:9050"
+                .parse::<IpcEndpoint>()
+                .expect("TCP endpoint should parse"),
+        );
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9050)]);
+        let filter =
+            config_filter_from_runtime_options(EnabledServices::CLIENT_API, endpoint.as_ref());
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "127.0.0.1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runtime_options_select_noop_filter_for_unix_proxy() {
+        let endpoint = Some(
+            "/run/tacacs/proxy.sock"
+                .parse::<IpcEndpoint>()
+                .expect("Unix endpoint should parse"),
+        );
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9050)]);
+        let filter =
+            config_filter_from_runtime_options(EnabledServices::TACACS_PROXY, endpoint.as_ref());
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn noop_filter_preserves_all_servers() {
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9050)]);
+
+        let filtered = NoopTacacsPlusFilter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn proxy_filter_removes_matching_ipv4_endpoint() {
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9050), ("192.0.2.20", 49)]);
+        let filter =
+            ProxySelfLoopFilter::new("127.0.0.1:9050".parse().expect("socket should parse"));
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "192.0.2.20");
+    }
+
+    #[tokio::test]
+    async fn proxy_filter_removes_matching_ipv6_endpoint() {
+        let config = test_config_from_host_ports(&[("::1", 9050), ("192.0.2.20", 49)]);
+        let filter = ProxySelfLoopFilter::new("[::1]:9050".parse().expect("socket should parse"));
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "192.0.2.20");
+    }
+
+    #[tokio::test]
+    async fn proxy_filter_resolves_localhost_hostname() {
+        let proxy_endpoint = tokio::net::lookup_host(("localhost", 9050))
+            .await
+            .expect("localhost should resolve")
+            .next()
+            .expect("localhost should have at least one address");
+        let config = test_config_from_host_ports(&[("localhost", 9050), ("192.0.2.20", 49)]);
+        let filter = ProxySelfLoopFilter::new(proxy_endpoint);
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "192.0.2.20");
+    }
+
+    #[tokio::test]
+    async fn proxy_filter_preserves_different_loopback_port() {
+        let config = test_config_from_host_ports(&[("127.0.0.1", 9051), ("192.0.2.20", 49)]);
+        let filter =
+            ProxySelfLoopFilter::new("127.0.0.1:9050".parse().expect("socket should parse"));
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn proxy_filter_preserves_non_loopback_same_port() {
+        let config = test_config_from_host_ports(&[("192.0.2.20", 9050)]);
+        let filter =
+            ProxySelfLoopFilter::new("127.0.0.1:9050".parse().expect("socket should parse"));
+
+        let filtered = filter.filter(config).await;
+
+        assert_eq!(filtered.server.len(), 1);
+        assert_eq!(filtered.server[0].address, "192.0.2.20");
+    }
+}

--- a/executables/tacacsrs_agentd/src/main.rs
+++ b/executables/tacacsrs_agentd/src/main.rs
@@ -20,10 +20,12 @@ use tacacsrs_datastore::{ConfigChange, ConfigDatastore};
 use tacacsrs_sonic::{SonicConfigDb, SonicConnection, DEFAULT_REDIS_URL};
 
 mod cli;
+mod config_filter;
 mod systemd_notify;
 
 use crate::cli::{Cli, ServiceMode};
 use crate::cli::PskKeyExchange;
+use crate::config_filter::{config_filter_from_runtime_options, TacacsPlusFilter};
 use crate::systemd_notify::SystemdNotifier;
 
 #[cfg(unix)]
@@ -166,6 +168,7 @@ async fn apply_config_change(
     label: &str,
     change: ConfigChange,
     service: &TacacsClientService,
+    config_filter: &dyn TacacsPlusFilter,
 ) -> anyhow::Result<()> {
     log::info!(
         "Datastore '{label}' reports configuration change: {} server(s); added={:?} removed={:?} modified={:?} root_metadata_changed={}",
@@ -175,7 +178,8 @@ async fn apply_config_change(
         change.delta.modified_servers,
         change.delta.root_metadata_changed,
     );
-    service.reload_tacacs_plus((*change.config).clone()).await
+    let config = config_filter.filter((*change.config).clone()).await;
+    service.reload_tacacs_plus(config).await
 }
 
 /// Spawn a background task that consumes [`ConfigDatastore::subscribe`]
@@ -184,6 +188,7 @@ fn spawn_change_listener(
     datastore: Arc<dyn ConfigDatastore>,
     service: Arc<TacacsClientService>,
     status_notifier: Arc<SystemdNotifier>,
+    config_filter: Arc<dyn TacacsPlusFilter>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let label = datastore.label();
@@ -196,7 +201,7 @@ fn spawn_change_listener(
         };
         log::info!("Subscribed to '{label}' configuration change notifications");
         while let Some(change) = stream.next().await {
-            match apply_config_change(label, change, &service).await {
+            match apply_config_change(label, change, &service, config_filter.as_ref()).await {
                 Ok(()) => {
                     log::info!(
                         "Applied datastore '{label}' configuration reload with {} upstream server(s) supporting authentication, authorization, and accounting",
@@ -266,6 +271,8 @@ async fn main() -> anyhow::Result<()> {
             "--proxy-endpoint requires --service-mode tacacs-proxy or --service-mode both"
         );
     }
+    let config_filter =
+        config_filter_from_runtime_options(enabled_services, proxy_endpoint.as_ref());
 
     let datastore = build_datastore(&cli);
     let tacacs_plus = {
@@ -273,7 +280,7 @@ async fn main() -> anyhow::Result<()> {
             format!("Failed to load configuration from datastore '{}'", datastore.label())
         })?;
         log::info!("Initial configuration loaded from datastore '{}'", datastore.label());
-        initial
+        config_filter.filter(initial).await
     };
 
     log::info!(
@@ -310,6 +317,7 @@ async fn main() -> anyhow::Result<()> {
         Arc::clone(&datastore),
         Arc::clone(&service),
         Arc::clone(&status_notifier),
+        Arc::clone(&config_filter),
     );
     service.serve().await
 }
@@ -324,6 +332,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{Cli, apply_config_change, cli_datastore_input_from_cli, enabled_services_from_cli};
+    use crate::config_filter::{NoopTacacsPlusFilter, ProxySelfLoopFilter};
     use tacacsrs_agent::{EnabledServices, ServiceConfig, TacacsClientService};
     use tacacsrs_agent_client::IpcEndpoint;
     use tacacsrs_config::PskDheKeSupportedGroup;
@@ -529,9 +538,32 @@ mod tests {
             config: Arc::new(updated),
         };
 
-        apply_config_change("test", change, &service).await.unwrap();
+        apply_config_change("test", change, &service, &NoopTacacsPlusFilter)
+            .await
+            .unwrap();
 
         assert_eq!(service.server_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn apply_config_change_filters_proxy_self_loop_on_reload() {
+        let initial = test_config(&["192.0.2.10:49"]);
+        let service = test_service(initial.clone());
+        assert_eq!(service.server_count(), 1);
+
+        let updated = test_config(&["127.0.0.1:9050", "192.0.2.11:49"]);
+        let change = ConfigChange {
+            delta: ConfigDelta::diff(Some(&initial), &updated),
+            config: Arc::new(updated),
+        };
+        let filter =
+            ProxySelfLoopFilter::new("127.0.0.1:9050".parse().expect("socket should parse"));
+
+        apply_config_change("test", change, &service, &filter)
+            .await
+            .unwrap();
+
+        assert_eq!(service.server_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces a runtime configuration filter to prevent the TACACS+ proxy from creating a self-loop by accidentally sending client traffic back into itself. The new filter removes any upstream TACACS+ server entries that resolve to the same address and port as the local TCP proxy endpoint, including loopback addresses and hostnames like `localhost`. The implementation is modular, allowing the filter to be enabled only when the proxy is active, and includes comprehensive unit tests.

Key changes:

**Proxy Self-Loop Protection:**
- Added a new `ProxySelfLoopFilter` in `config_filter.rs` that removes upstream TACACS+ servers matching the local TCP proxy endpoint, preventing proxy self-loops and potential packet storms. This includes resolving hostnames and handling both IPv4 and IPv6 loopbacks.
- Updated the documentation in `README.md` to warn users against configuring the proxy endpoint as an upstream server and to describe the new automatic filtering behavior.

**Integration with Daemon:**
- Integrated the configuration filter into the daemon's startup and configuration reload paths in `main.rs`, ensuring that filtered configurations are applied both at startup and during runtime reloads. [[1]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R23-R28) [[2]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R171) [[3]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L178-R182) [[4]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R191) [[5]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L199-R204) [[6]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R274-R283) [[7]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R320)

**Testing:**
- Added extensive unit tests for the configuration filter, covering various scenarios including loopback addresses, hostnames, different ports, and proxy-disabled modes.
- Added a specific test to verify that configuration reloads correctly filter out self-looping proxy endpoints. [[1]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9R335) [[2]](diffhunk://#diff-8271a39638662872531912534c1e537091ab5f867b47cf3dc8ed9b944c9e78b9L532-R568)